### PR TITLE
[ENG-2345] Improve responsive experience on error pages

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -559,6 +559,14 @@ screen.twofactor.button.verify=Verify
 screen.twofactor.button.verifywip=One moment please...
 screen.twofactor.button.cancel=Cancel
 #
+# Generic logout success page
+#
+screen.generic.logout.header=Signed-out
+screen.generic.logout.heading=Logout successful
+screen.generic.logout.message=You have successfully logged out of the OSF Central Authentication Service (CAS). You may continue to OSF signed-out or return to the sign-in page.
+screen.generic.button.backtoosf=Continue to OSF
+screen.generic.button.backtologin=Return to sign-in
+#
 # Authentication exception messages on the login form submission page (inline / pop-up)
 #
 username.required=Email is required.
@@ -623,6 +631,7 @@ screen.institutionssonotimplemented.message=The implementation of institution lo
 # OSF
 #
 osf.home.url=https://staging3.osf.io/
+osf.logout.url=https://staging3.osf.io/logout
 osf.resend.osf.confirmation.url=https://staging3.osf.io/resend/
 osf.forgot.password.url=https://staging3.osf.io/forgotpassword/
 osf.create.account.url=https://staging3.osf.io/register/

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -263,7 +263,7 @@ UNAUTHORIZED_SERVICE_PROXY=The supplied service ''{0}'' is not authorized to use
 UNSATISFIED_AUTHN_POLICY=Service access denied due to an unsatisfied authentication policy.
 INVALID_AUTHN_REQUEST=Authentication attempt has failed, likely due to invalid credentials.
 
-screen.service.error.header=Application Not Authorized to Use CAS
+# screen.service.error.header=Application Not Authorized to Use CAS
 service.principal.resolution.error=CAS is unable to determine the correct authentication principal. \
   Either the principal could not be resolved correctly as a single unique entity or CAS has found \
   mixed/multiple candidate principals and is unable to decide which should be used. \
@@ -271,10 +271,10 @@ service.principal.resolution.error=CAS is unable to determine the correct authen
   due to missing privileges set by the CAS server authorization policies.
 service.not.authorized.missing.attr=You are not authorized to access the application as your account \
 is missing privileges required by the CAS server to authenticate into this service. Please notify your support desk.
-screen.service.error.message=The application you attempted to authenticate to is not authorized to use CAS. \
-  This usually indicates that the application is not registered with CAS, or its authorization policy defined in its registration record \
-  prevents it from leveraging CAS functionality, or it's malformed and unrecognized by CAS. \
-  Contact your CAS administrator to learn how you might register and integrate your application with CAS.
+# screen.service.error.message=The application you attempted to authenticate to is not authorized to use CAS. \
+#   This usually indicates that the application is not registered with CAS, or its authorization policy defined in its registration record \
+#   prevents it from leveraging CAS functionality, or it's malformed and unrecognized by CAS. \
+#   Contact your CAS administrator to learn how you might register and integrate your application with CAS.
 screen.service.empty.error.message=The services registry of CAS is empty and has no service definitions. \
 Applications that wish to authenticate with CAS must explicitly be defined in the services registry.
 screen.service.expired.message=The application you attempted to authenticate to has been expired in the CAS Service Registry. \
@@ -593,12 +593,17 @@ screen.accountnotconfirmedosf.heading=Account not confirmed
 screen.accountnotconfirmedosf.message=The OSF account associated with the email has been registered but not confirmed. \
   Please check your email (and spam folder) or click the button below to resend your confirmation email.
 screen.unavailable.header=CAS Error
-screen.unavailable.heading=Service unavailable
+screen.unavailable.heading=CAS unavailable
 screen.unavailable.message=Your request cannot be completed at this time. Please return to OSF and try again later. If \
   this issue persists, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> with \
   a copy of the error details below.
 screen.unavailable.button.viewdetails=View error details
 screen.unavailable.button.hidedetails=Hide error details
+screen.service.error.header=Service Error
+screen.service.error.heading=Service not authorized
+screen.service.error.message=The application you attempted to authenticate to is not authorized to use OSF CAS. Please \
+  return to OSF and try again. If this issue persists, please contact <a style="white-space: nowrap" \
+  href="mailto:support@osf.io">OSF Support</a>
 screen.invaliduserstatus.heading=Account not valid
 screen.invaliduserstatus.message=Cannot log in to an invalid account. If you believe this should not happen, please \
   contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a>.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -519,14 +519,11 @@ cas.login.resources.cos.home=COS Home
 #
 # Footer
 #
-copyright=Copyright &copy; 2011 &ndash; 2020 <a style="white-space: nowrap" href="https://cos.io">Center for Open Science</a> &#124; \
-  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> &#124; \
-  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> &#124; \
-  <a style="white-space: nowrap" href="https://status.cos.io/">Status</a> &#124; \
-  <a style="white-space: nowrap" href="https://developer.osf.io/">API</a><br> \
-  <a style="white-space: nowrap" href="http://cos.io/top/">TOP Guidelines</a> &#124; \
-  <a style="white-space: nowrap" href="https://osf.io/ezcuj/wiki/home/">Reproducibility Project: Psychology</a> &#124; \
-  <a style="white-space: nowrap" href="https://osf.io/e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a>
+copyright.cos=<span style="white-space: nowrap">Copyright &copy; 2011 &ndash; 2020</span>&#160;\
+  <a style="white-space: nowrap" href="https://cos.io">Center for Open Science</a> &#124;&#160;\
+  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a>&#160;&#124;&#160;\
+  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>&#160;&#124;&#160;\
+  <a style="white-space: nowrap" href="https://status.cos.io/">Status</a>
 #
 # IdP SSO
 #

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -559,13 +559,19 @@ screen.twofactor.button.verify=Verify
 screen.twofactor.button.verifywip=One moment please...
 screen.twofactor.button.cancel=Cancel
 #
-# Generic logout success page
+# Generic login and logout success page
 #
 screen.generic.logout.header=Signed-out
 screen.generic.logout.heading=Logout successful
 screen.generic.logout.message=You have successfully logged out of the OSF Central Authentication Service (CAS). You may continue to OSF signed-out or return to the sign-in page.
+screen.generic.login.header=Signed-in
+screen.generic.login.heading=Login successful
+screen.generic.login.message=You have successfully logged into the OSF Central Authentication Service (CAS). You may continue to OSF signed-in or log out and go back to OSF home page.
 screen.generic.button.backtoosf=Continue to OSF
 screen.generic.button.backtologin=Return to sign-in
+screen.generic.button.logout=Log out
+screen.generic.button.viewdetails=View authentication details
+screen.generic.button.hidedetails=Hide authentication details
 #
 # Authentication exception messages on the login form submission page (inline / pop-up)
 #

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -552,12 +552,13 @@ screen.delegation.heading.orcidredirect=Redirecting to ORCiD
 # Two factor and login form submission
 #
 cas.twofactor.pagetitle=Sign in
-screen.twofactor.instructions=Enter your one-time password to finish login
+screen.twofactor.instructions.top=Enter your one-time password to finish login
 screen.twofactor.label.onetimepassword=<span class="accesskey">O</span>ne-time password (6-digit)
 screen.twofactor.label.onetimepassword.accesskey=o
 screen.twofactor.button.verify=Verify
 screen.twofactor.button.verifywip=One moment please...
 screen.twofactor.button.cancel=Cancel
+screen.twofactor.instructions.bottom=Open the two-factor authentication app on your device to view your authentication code and verify your identity.
 #
 # Generic login and logout success page
 #

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -643,7 +643,6 @@ body {
 }
 
 .service-ui {
-    text-align: center;
     margin-top: 1rem!important;
     margin-bottom: 1rem!important;
 }
@@ -666,9 +665,14 @@ body {
     margin: 1rem 0;
 }
 
-.text-with-mdi {
+.text-with-mdi,
+.text-without-mdi {
     font-size: 1rem;
     margin: 0.5rem 0;
+}
+
+.login-section .text-with-mdi {
+    white-space: nowrap;
 }
 
 .mdi-before-text {
@@ -839,9 +843,67 @@ body {
 .banner-danger .title-danger {
     margin: 0.5rem 0;
     color: var(--cas-theme-osf-red, #b52b27);
+    white-space: nowrap;
 }
 
 .banner-generic hr,
 .banner-danger hr {
     width: 100%;
+}
+
+.card-message {
+    padding: 1rem 0;
+}
+
+.w-card-narrow .card-message {
+    max-width: 36rem;
+}
+
+.w-card-wide .card-message {
+    max-width: 48rem;
+}
+
+@media all and (min-width: 640px) {
+    .w-card-narrow {
+        width: 50%;
+    }
+    .w-card-wide {
+        width: 75%;
+    }
+}
+
+@media all and (max-width: 640px) {
+    .w-card-narrow {
+        width: 100%;
+    }
+    .w-card-wide {
+        width: 100%;
+    }
+    footer {
+        display: none
+    }
+}
+
+@media all and (max-width: 480px) {
+    .text-center {
+        text-align: left;
+    }
+    .service-ui .service-ui-logo {
+        max-width: 240px;
+    }
+    .service-ui-info .service-ui-desc {
+        display: none;
+    }
+    .login-section .mdi-before-text {
+        display: none;
+    }
+    .login-section .text-with-mdi {
+        font-size: 0.75rem;
+    }
+    .login-section .text-without-mdi {
+        font-size: 0.75rem;
+    }
+    .login-error-card .title-danger {
+        font-size: 0.875rem;
+    }
 }

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -810,7 +810,8 @@ body {
     margin: 0.25rem 0;
 }
 
-.login-error-card {
+.login-error-card,
+.login-generic-card {
     min-width: fit-content;
 }
 
@@ -819,6 +820,7 @@ body {
     white-space: pre-wrap;
 }
 
+.banner-generic,
 .banner-danger {
     min-width: fit-content;
 }
@@ -838,6 +840,7 @@ body {
     color: var(--cas-theme-osf-red, #b52b27);
 }
 
+.banner-generic hr,
 .banner-danger hr {
     width: 100%;
 }

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -863,7 +863,7 @@ body {
     max-width: 48rem;
 }
 
-@media all and (min-width: 640px) {
+@media all and (min-width: 639.99px) {
     .w-card-narrow {
         width: 50%;
     }
@@ -872,7 +872,7 @@ body {
     }
 }
 
-@media all and (max-width: 640px) {
+@media all and (min-width: 479.99px) and (max-width: 639.99px) {
     .w-card-narrow {
         width: 100%;
     }
@@ -884,13 +884,82 @@ body {
     }
 }
 
-@media all and (max-width: 480px) {
-    .text-center {
-        text-align: left;
+@media all and (min-height: 1439.99) {
+    .mdc-top-app-bar__row {
+        height: 64px;
+    }
+    .cas-brand {
+        height: 56px;
+    }
+    .mdc-top-app-bar--fixed-adjust {
+        padding-top: 72px;
+    }
+    .mdc-drawer {
+        top: 56px;
+    }
+    .cas-footer-osf {
+        font-size: 1rem;
+        padding-bottom: 1.5rem!important;
+        padding-top: 1.5rem!important;
+        text-align: center;
+    }
+}
+
+@media all and (min-width: 639.99px),
+all and (min-height: 1079.99) {
+    .mdc-top-app-bar__row {
+        height: 56px;
+    }
+    .cas-brand {
+        height: 48px;
+    }
+    .mdc-top-app-bar--fixed-adjust {
+        padding-top: 64px;
+    }
+    .mdc-drawer {
+        top: 48px;
+    }
+    .cas-footer-osf {
+        font-size: 0.875rem;
+        padding-bottom: 1rem!important;
+        padding-top: 1rem!important;
+        text-align: center;
+    }
+}
+
+@media all and (min-width: 479.99px) and (max-width: 639.99px),
+all and (max-height: 1079.99px) {
+    .mdc-top-app-bar__row {
+        height: 40px;
+    }
+    .cas-brand {
+        height: 32px;
+    }
+    .mdc-drawer {
+        top: 32px;
+    }
+    .mdc-top-app-bar--fixed-adjust {
+        padding-top: 32px;
+    }
+    .cas-footer-osf {
+        font-size: 0.75rem;
+        padding-bottom: 0.75rem!important;
+        padding-top: 0.75rem!important;
+        text-align: center;
+    }
+}
+
+@media all and (max-width: 479.99px),
+all and (max-height: 899.99px) {
+    .service-ui {
+        margin-top: 0.5rem!important;
+        margin-bottom: 0.5rem!important;
     }
     .service-ui .service-ui-logo {
         max-width: 240px;
+        max-height: 3rem;
     }
+    .service-ui-info .service-ui-name,
     .service-ui-info .service-ui-desc {
         display: none;
     }
@@ -905,5 +974,23 @@ body {
     }
     .login-error-card .title-danger {
         font-size: 0.875rem;
+    }
+    .mdc-top-app-bar__row {
+        height: 32px;
+    }
+    .cas-brand {
+        height: 24px;
+    }
+    .mdc-drawer {
+        top: 32px;
+    }
+    .mdc-top-app-bar--fixed-adjust {
+        padding-top: 16px;
+    }
+    .cas-footer-osf {
+        font-size: 0.625rem;
+        padding-bottom: 0.5rem!important;
+        padding-top: 0.5rem!important;
+        text-align: center;
     }
 }

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -742,7 +742,8 @@ body {
     font-size: 1rem;
 }
 
-.login-error-card .hr-text {
+.login-error-card .hr-text,
+.login-generic-card .hr-text {
     margin: 1.5rem 0;
 }
 

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.accountdisabled.heading}"></h2>
                 <p th:utext="#{screen.accountdisabled.message}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.accountdisabled.heading}"></h2>
-                <p th:utext="#{screen.accountdisabled.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.accountdisabled.heading}"></h2>
+                    <p th:utext="#{screen.accountdisabled.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.accountnotconfirmedidp.heading}"></h2>
                 <p th:utext="#{screen.accountnotconfirmedidp.message}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.accountnotconfirmedidp.heading}"></h2>
-                <p th:utext="#{screen.accountnotconfirmedidp.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.accountnotconfirmedidp.heading}"></h2>
+                    <p th:utext="#{screen.accountnotconfirmedidp.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -28,7 +28,7 @@
                     </a>
                 </div>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.accountnotconfirmedosf.heading}"></h2>
-                <p th:utext="#{screen.accountnotconfirmedosf.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.accountnotconfirmedosf.heading}"></h2>
+                    <p th:utext="#{screen.accountnotconfirmedosf.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-green" th:href="#{osf.resend.osf.confirmation.url}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.resendosfconfirmation}"></span>
@@ -36,4 +38,5 @@
         </div>
     </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -12,16 +12,16 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div layout:fragment="content" class="row">
-
-            <div class="banner-generic m-auto mdc-card p-4">
-
+            <div class="banner-generic m-auto mdc-card p-4 w-card-wide">
                 <div class="login-generic-card">
                     <div th:replace="fragments/osfbannerui :: osfBannerUI">
                         <a href="fragments/osfbannerui.html"></a>
                     </div>
                     <hr class="my-4" />
-                    <h2 th:utext="#{screen.generic.login.heading}"></h2>
-                    <p th:utext="#{screen.generic.login.message}"></p>
+                    <div class="card-message">
+                        <h2 th:utext="#{screen.generic.login.heading}"></h2>
+                        <p th:utext="#{screen.generic.login.message}"></p>
+                    </div>
                     <div class="form-button-inline">
                         <a class="mdc-button mdc-button--raised button-osf-green" th:href="@{#{osf.home.url}}">
                             <span class="mdc-button__label" th:utext="#{screen.generic.button.backtoosf}"></span>
@@ -73,7 +73,6 @@
                     </div>
                 </div>
             </div>
-
             <script type="text/javascript" th:inline="javascript">
                 let div = document.querySelector('#divPrincipalAttributes');
                 new mdc.dataTable.MDCDataTable(div);
@@ -91,7 +90,6 @@
                 }
                 /*]]>*/
             </script>
-
         </div>
     </main>
 </body>

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -5,54 +5,95 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 
-    <title th:text="#{screen.success.header}"></title>
+    <title th:text="#{screen.generic.login.header}"></title>
     <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="row">
-        <div class="w-100 m-auto mdc-card p-4">
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="row">
 
-            <h2 th:utext="#{screen.success.header}"></h2>
-            <p th:utext="#{screen.success.success(${authentication.principal.id})}"></p>
-            <p th:unless="${#maps.isEmpty(authentication.principal.attributes)}">
+            <div class="banner-generic m-auto mdc-card p-4">
 
-                The following attributes are resolved for <strong th:utext="${authentication.principal.id}" />:
-
-                <div class="w-100 mdc-data-table mx-auto my-4" id="divPrincipalAttributes">
-                    <table id="attributesTable" class="mdc-data-table__table" style="white-space: unset">
-                        <thead>
-                        <tr class="mdc-data-table__header-row">
-                            <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Attribute</th>
-                            <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Value(s)</th>
-                            <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Type</th>
-                        </tr>
-                        </thead>
-                        <tbody class="mdc-data-table__content">
-                        <tr th:each="attribute : ${authentication.principal.attributes}" class="mdc-data-table__row">
-                            <td class="mdc-data-table__cell"><code><span th:utext="${attribute.key}"/></code></td>
-                            <td class="mdc-data-table__cell"><code><span th:utext="${attribute.value}"/></code></td>
-                            <td class="mdc-data-table__cell"><code>Principal</code></td>
-                        </tr>
-                        <tr th:each="attribute : ${authentication.attributes}" class="mdc-data-table__row">
-                            <td class="mdc-data-table__cell"><code><span th:utext="${attribute.key}"/></code></td>
-                            <td class="mdc-data-table__cell"><code><span th:utext="${attribute.value}"/></code></td>
-                            <td class="mdc-data-table__cell"><code>Authentication</code></td>
-                        </tr>
-                        </tbody>
-                    </table>
+                <div class="login-generic-card">
+                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
+                        <a href="fragments/osfbannerui.html"></a>
+                    </div>
+                    <hr class="my-4" />
+                    <h2 th:utext="#{screen.generic.login.heading}"></h2>
+                    <p th:utext="#{screen.generic.login.message}"></p>
+                    <div class="form-button-inline">
+                        <a class="mdc-button mdc-button--raised button-osf-green" th:href="@{#{osf.home.url}}">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.backtoosf}"></span>
+                        </a>
+                        <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.logout}"></span>
+                        </a>
+                    </div>
+                    <hr class="hr-text" data-content="DEVELOPING MODE ONLY" />
+                    <div class="form-button">
+                        <button id="buttonViewAuthenticationDetails" type="button"
+                            class="mdc-button mdc-button--raised button-osf-red"
+                            onclick="showAuthenticationDetails();">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.viewdetails}"></span>
+                        </button>
+                        <button id="buttonHideAuthenticationDetails" type="button" style="display: none;"
+                            class="mdc-button mdc-button--raised button-osf-red"
+                            onclick="hideAuthenticationrDetails();">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.hidedetails}"></span>
+                        </button>
+                    </div>
+                    <div id="authenticationDetails" class="pre-formatted-small word-break-all" style="display: none;">
+                        <p th:unless="${#maps.isEmpty(authentication.principal.attributes)}">
+                            The following attributes are resolved for <strong th:utext="${authentication.principal.id}"></strong>:
+                            <div class="w-100 mdc-data-table mx-auto my-4" id="divPrincipalAttributes">
+                                <table id="attributesTable" class="mdc-data-table__table" style="white-space: unset">
+                                    <thead>
+                                    <tr class="mdc-data-table__header-row">
+                                        <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Attribute</th>
+                                        <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Value(s)</th>
+                                        <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Type</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody class="mdc-data-table__content">
+                                    <tr th:each="attribute : ${authentication.principal.attributes}" class="mdc-data-table__row">
+                                        <td class="mdc-data-table__cell"><code><span th:utext="${attribute.key}"></span></code></td>
+                                        <td class="mdc-data-table__cell"><code><span th:utext="${attribute.value}"></span></code></td>
+                                        <td class="mdc-data-table__cell"><code>Principal</code></td>
+                                    </tr>
+                                    <tr th:each="attribute : ${authentication.attributes}" class="mdc-data-table__row">
+                                        <td class="mdc-data-table__cell"><code><span th:utext="${attribute.key}"></span></code></td>
+                                        <td class="mdc-data-table__cell"><code><span th:utext="${attribute.value}"></span></code></td>
+                                        <td class="mdc-data-table__cell"><code>Authentication</code></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </p>
+                    </div>
                 </div>
+            </div>
 
-            </p>
-            <p th:utext="#{screen.success.security}"></p>
+            <script type="text/javascript" th:inline="javascript">
+                let div = document.querySelector('#divPrincipalAttributes');
+                new mdc.dataTable.MDCDataTable(div);
+
+                /*<![CDATA[*/
+                function showAuthenticationDetails() {
+                    $("#buttonViewAuthenticationDetails").hide()
+                    $("#buttonHideAuthenticationDetails").show()
+                    $("#authenticationDetails").show()
+                }
+                function hideAuthenticationrDetails() {
+                    $("#buttonViewAuthenticationDetails").show()
+                    $("#buttonHideAuthenticationDetails").hide()
+                    $("#authenticationDetails").hide()
+                }
+                /*]]>*/
+            </script>
+
         </div>
-
-        <script type="text/javascript" th:inline="javascript">
-            let div = document.querySelector('#divPrincipalAttributes');
-            new mdc.dataTable.MDCDataTable(div);
-        </script>
-    </div>
-</main>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/casInstitutionSsoNotImplementedView.html
+++ b/src/main/resources/templates/casInstitutionSsoNotImplementedView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.institutionssonotimplemented.heading}"></h2>
                 <p th:utext="#{screen.institutionssonotimplemented.message}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casInstitutionSsoNotImplementedView.html
+++ b/src/main/resources/templates/casInstitutionSsoNotImplementedView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.institutionssonotimplemented.heading}"></h2>
-                <p th:utext="#{screen.institutionssonotimplemented.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.institutionssonotimplemented.heading}"></h2>
+                    <p th:utext="#{screen.institutionssonotimplemented.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.invaliduserstatus.heading}"></h2>
-                <p th:utext="#{screen.invaliduserstatus.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.invaliduserstatus.heading}"></h2>
+                    <p th:utext="#{screen.invaliduserstatus.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.invaliduserstatus.heading}"></h2>
                 <p th:utext="#{screen.invaliduserstatus.message}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.invalidverificationkey.heading}"></h2>
                 <p th:utext="#{screen.invalidverificationkey.message}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -11,17 +11,19 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.invalidverificationkey.heading}"></h2>
-                <p th:utext="#{screen.invalidverificationkey.message}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.invalidverificationkey.heading}"></h2>
+                    <p th:utext="#{screen.invalidverificationkey.message}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -5,20 +5,35 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 
-    <title th:text="#{screen.logout.header}"></title>
+    <title th:text="#{screen.generic.logout.header}"></title>
     <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content">
-        <div class="w-50 m-auto mdc-card p-4">
-            <h2 class="banner-heading" th:utext="#{screen.logout.header}"></h2>
-            <p class="banner-message" th:utext="#{screen.logout.success}"></p>
-            <p class="banner-message" th:utext="#{screen.logout.security}"></p>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content">
+            <div class="banner-generic m-auto mdc-card p-4">
+                <div class="login-generic-card">
+                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
+                        <a href="fragments/osfbannerui.html"></a>
+                    </div>
+                    <hr class="my-4" />
+                    <h2 th:utext="#{screen.generic.logout.heading}"></h2>
+                    <p th:utext="#{screen.generic.logout.message}"></p>
+                    <div class="form-button">
+                        <a class="mdc-button mdc-button--raised button-osf-green" th:href="@{/login}">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.backtologin}"></span>
+                        </a>
+                    </div>
+                    <div class="form-button">
+                        <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
+                            <span class="mdc-button__label" th:utext="#{screen.generic.button.backtoosf}"></span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-</main>
+    </main>
 </body>
 
 </html>

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -12,14 +12,16 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div layout:fragment="content">
-            <div class="banner-generic m-auto mdc-card p-4">
+            <div class="banner-generic m-auto mdc-card p-4 w-card-narrow">
                 <div class="login-generic-card">
                     <div th:replace="fragments/osfbannerui :: osfBannerUI">
                         <a href="fragments/osfbannerui.html"></a>
                     </div>
                     <hr class="my-4" />
-                    <h2 th:utext="#{screen.generic.logout.heading}"></h2>
-                    <p th:utext="#{screen.generic.logout.message}"></p>
+                    <div class="card-message">
+                        <h2 th:utext="#{screen.generic.logout.heading}"></h2>
+                        <p th:utext="#{screen.generic.logout.message}"></p>
+                    </div>
                     <div class="form-button">
                         <a class="mdc-button mdc-button--raised button-osf-green" th:href="@{/login}">
                             <span class="mdc-button__label" th:utext="#{screen.generic.button.backtologin}"></span>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -11,7 +11,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-card-narrow">
             <div class="login-error-card">
                 <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
@@ -20,8 +20,10 @@
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.service.error.heading}"></h2>
-                <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.service.error.heading}"></h2>
+                    <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>
+                </div>
                 <div class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -23,7 +23,7 @@
                 <h2 th:utext="#{screen.service.error.heading}"></h2>
                 <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>
                 <div class="form-button">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                 </div>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -10,25 +10,26 @@
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
-        <div class="login-error-card">
-            <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
-                <a href="fragments/osfbannerui.html"></a>
-            </div>
-            <h3 class="text-center title-danger">
-                <span th:utext="#{screen.authnerror.instructions}"></span>
-            </h3>
-            <hr class="my-4" />
-            <h2 th:utext="#{screen.service.error.header}"></h2>
-            <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>
-            <div class="form-button">
-                <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
-                    <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
-                </a>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto">
+            <div class="login-error-card">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
+                    <a href="fragments/osfbannerui.html"></a>
+                </div>
+                <h3 class="text-center title-danger">
+                    <span th:utext="#{screen.authnerror.instructions}"></span>
+                </h3>
+                <hr class="my-4" />
+                <h2 th:utext="#{screen.service.error.heading}"></h2>
+                <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>
+                <div class="form-button">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                        <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
+                    </a>
+                </div>
             </div>
         </div>
-    </div>
-</main>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -24,7 +24,7 @@
                 <h2 th:utext="#{screen.unavailable.heading}"></h2>
                 <div th:utext="#{screen.unavailable.message}"></div>
                 <div class="form-button-inline">
-                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
                     </a>
                     <button id="buttonViewErrorDetails" type="button"

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -11,7 +11,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger mdc-card p-4">
+        <div layout:fragment="content" class="banner banner-danger mdc-card p-4 w-md-wide">
 
             <div class="login-error-card">
                 <div th:replace="fragments/osfbannerui :: osfBannerUI">
@@ -21,8 +21,10 @@
                     <span th:utext="#{screen.authnerror.instructions}"></span>
                 </h3>
                 <hr class="my-4" />
-                <h2 th:utext="#{screen.unavailable.heading}"></h2>
-                <div th:utext="#{screen.unavailable.message}"></div>
+                <div class="card-message">
+                    <h2 th:utext="#{screen.unavailable.heading}"></h2>
+                    <div th:utext="#{screen.unavailable.message}"></div>
+                </div>
                 <div class="form-button-inline">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                         <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -12,8 +12,9 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div layout:fragment="content" class="banner banner-danger mdc-card p-4">
+
             <div class="login-error-card">
-                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
                     <a href="fragments/osfbannerui.html"></a>
                 </div>
                 <h3 class="text-center title-danger">
@@ -60,6 +61,7 @@
                 }
                 /*]]>*/
             </script>
+
         </div>
     </main>
 </body>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,3 +1,3 @@
-<footer class="py-4 d-flex justify-content-center cas-footer">
-    <span id="copyright" th:utext="#{copyright}" class="mr-2 d-inline-block"></span>
+<footer class="py-4 d-flex justify-content-center cas-footer cas-footer-osf">
+    <span id="copyright" th:utext="#{copyright.cos}" class="mr-2 d-inline-block copyright"></span>
 </footer>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -10,122 +10,121 @@
 </head>
 
 <body>
+    <div th:fragment="header">
 
-<div th:fragment="header">
-
-    <header id="app-bar" class="mdc-top-app-bar mdc-top-app-bar--fixed mdc-elevation--z4">
-        <nav class="mdc-top-app-bar__row">
-            <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-                <button class="mdc-icon-button mdc-top-app-bar__navigation-icon">
-                    <span class="mdi mdi-menu"></span>
-                    <span class="sr-only">menu</span>
-                </button>
-            </section>
-            <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
-                <span class="cas-brand mx-auto">
-                    <img class="cas-logo" src="/images/osf-cas-banner-white.png">
-                    <span class="sr-only">OSF CAS</span>
-                </span>
-            </section>
-            <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
-            </section>
-        </nav>
-    </header>
-
-    <aside id="app-drawer" class="mdc-drawer mdc-drawer--dismissible mdc-drawer--modal">
-        <div class="mdc-drawer__header">
-            <img class="cas-brand cas-brand-drawer" src="/images/osf-cas-banner.png">
-            <h6 class="mdc-drawer__subtitle">[[#{cas.drawer.subtitle}]]</h6>
-        </div>
-        <div class="mdc-drawer__content">
-            <nav class="mdc-list">
-                <a class="mdc-list-item" th:href="#{osf.home.url}">
-                    <i class="mdi mdi-home"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.home}]]</span>
-                </a>
-                <hr class="mdc-list-divider"/>
-                <a class="mdc-list-item" th:href="#{osf.preprints.home.url}">
-                    <i class="mdi mdi-star"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.preprints}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.registries.home.url}">
-                    <i class="mdi mdi-star"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.registries}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.institutions.home.url}">
-                    <i class="mdi mdi-bank"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.institutions}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.meetings.home.url}">
-                    <i class="mdi mdi-account-group"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.meetings}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.support.url}">
-                    <i class="mdi mdi-help-circle"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.osf.support}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.cos.donation.url}">
-                    <i class="mdi mdi-heart"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.cos.donate}]]</span>
-                </a>
-                <a class="mdc-list-item" th:href="#{osf.cos.home.url}">
-                    <i class="mdi mdi-lightbulb-on"></i>&nbsp;
-                    <span class="mdc-list-item__text">[[#{cas.login.resources.cos.home}]]</span>
-                </a>
+        <header id="app-bar" class="mdc-top-app-bar mdc-top-app-bar--fixed mdc-elevation--z4">
+            <nav class="mdc-top-app-bar__row">
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+                    <button class="mdc-icon-button mdc-top-app-bar__navigation-icon">
+                        <span class="mdi mdi-menu"></span>
+                        <span class="sr-only">menu</span>
+                    </button>
+                </section>
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
+                    <span class="cas-brand mx-auto">
+                        <img class="cas-logo" src="/images/osf-cas-banner-white.png">
+                        <span class="sr-only">OSF CAS</span>
+                    </span>
+                </section>
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
+                </section>
             </nav>
-        </div>
-    </aside>
+        </header>
 
-    <script type="text/javascript">
-        (function (material) {
-            var header = {
-                init: function () {
-                    header.attachTopbar();
-                    material.autoInit();
-                },
-                attachDrawer: function () {
-                    var elm = document.getElementById('app-drawer');
-                    var drawer = material.drawer.MDCDrawer.attachTo(elm);
-                    var closeDrawer = function (evt) {
-                        drawer.open = false;
-                    };
-                    drawer.foundation_.handleScrimClick = closeDrawer;
-                    document.onkeydown = function (evt) {
-                        evt = evt || window.event;
-                        if (evt.keyCode == 27) {
-                            closeDrawer();
+        <aside id="app-drawer" class="mdc-drawer mdc-drawer--dismissible mdc-drawer--modal">
+            <div class="mdc-drawer__header">
+                <img class="cas-brand cas-brand-drawer" src="/images/osf-cas-banner.png">
+                <h6 class="mdc-drawer__subtitle">[[#{cas.drawer.subtitle}]]</h6>
+            </div>
+            <div class="mdc-drawer__content">
+                <nav class="mdc-list">
+                    <a class="mdc-list-item" th:href="#{osf.home.url}">
+                        <i class="mdi mdi-home"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.home}]]</span>
+                    </a>
+                    <hr class="mdc-list-divider"/>
+                    <a class="mdc-list-item" th:href="#{osf.preprints.home.url}">
+                        <i class="mdi mdi-star"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.preprints}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.registries.home.url}">
+                        <i class="mdi mdi-star"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.registries}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.institutions.home.url}">
+                        <i class="mdi mdi-bank"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.institutions}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.meetings.home.url}">
+                        <i class="mdi mdi-account-group"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.meetings}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.support.url}">
+                        <i class="mdi mdi-help-circle"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.osf.support}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.cos.donation.url}">
+                        <i class="mdi mdi-heart"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.cos.donate}]]</span>
+                    </a>
+                    <a class="mdc-list-item" th:href="#{osf.cos.home.url}">
+                        <i class="mdi mdi-lightbulb-on"></i>&nbsp;
+                        <span class="mdc-list-item__text">[[#{cas.login.resources.cos.home}]]</span>
+                    </a>
+                </nav>
+            </div>
+        </aside>
+
+        <script type="text/javascript">
+            (function (material) {
+                var header = {
+                    init: function () {
+                        header.attachTopbar();
+                        material.autoInit();
+                    },
+                    attachDrawer: function () {
+                        var elm = document.getElementById('app-drawer');
+                        var drawer = material.drawer.MDCDrawer.attachTo(elm);
+                        var closeDrawer = function (evt) {
+                            drawer.open = false;
+                        };
+                        drawer.foundation_.handleScrimClick = closeDrawer;
+                        document.onkeydown = function (evt) {
+                            evt = evt || window.event;
+                            if (evt.keyCode == 27) {
+                                closeDrawer();
+                            }
+                        };
+                        header.drawer = drawer;
+                        return drawer;
+                    },
+                    attachTopbar: function (drawer) {
+                        var drawer = header.attachDrawer();
+                        header.attachDrawerToggle(drawer);
+                    },
+                    checkCaps: function (ev) {
+                        var s = String.fromCharCode(ev.which);
+                        if (s.toUpperCase() === s && s.toLowerCase() !== s && !ev.shiftKey) {
+                            ev.target.parentElement.classList.add('caps-on');
+                        } else {
+                            ev.target.parentElement.classList.remove('caps-on');
                         }
-                    };
-                    header.drawer = drawer;
-                    return drawer;
-                },
-                attachTopbar: function (drawer) {
-                    var drawer = header.attachDrawer();
-                    header.attachDrawerToggle(drawer);
-                },
-                checkCaps: function (ev) {
-                    var s = String.fromCharCode(ev.which);
-                    if (s.toUpperCase() === s && s.toLowerCase() !== s && !ev.shiftKey) {
-                        ev.target.parentElement.classList.add('caps-on');
-                    } else {
-                        ev.target.parentElement.classList.remove('caps-on');
+                    },
+                    attachDrawerToggle: function (drawer) {
+                        var topAppBar = material.topAppBar.MDCTopAppBar.attachTo(document.getElementById('app-bar'));
+                        topAppBar.setScrollTarget(document.getElementById('main-content'));
+                        topAppBar.listen('MDCTopAppBar:nav', function () {
+                            drawer.open = !drawer.open;
+                        });
+                        return topAppBar;
                     }
-                },
-                attachDrawerToggle: function (drawer) {
-                    var topAppBar = material.topAppBar.MDCTopAppBar.attachTo(document.getElementById('app-bar'));
-                    topAppBar.setScrollTarget(document.getElementById('main-content'));
-                    topAppBar.listen('MDCTopAppBar:nav', function () {
-                        drawer.open = !drawer.open;
-                    });
-                    return topAppBar;
                 }
-            }
-            document.addEventListener('DOMContentLoaded', function () {
-                header.init();
-            });
-        })(mdc);
-    </script>
-
-</div>
+                document.addEventListener('DOMContentLoaded', function () {
+                    header.init();
+                });
+            })(mdc);
+        </script>
+    </div>
 </body>
+
 </html>

--- a/src/main/resources/templates/fragments/osfbannerui.html
+++ b/src/main/resources/templates/fragments/osfbannerui.html
@@ -12,7 +12,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div th:fragment="osfBannerUI" id="osfbannerui" class="mb-4 service-ui">
+        <div th:fragment="osfBannerUI" id="osfbannerui" class="mb-4 service-ui text-center">
             <img id="servicelogo" class="service-ui-logo" src="/images/osf-banner.png" />
         </div>
     </main>

--- a/src/main/resources/templates/fragments/pmlinks.html
+++ b/src/main/resources/templates/fragments/pmlinks.html
@@ -26,4 +26,5 @@
         </div>
     </div>
 </body>
+
 </html>

--- a/src/main/resources/templates/fragments/serviceui.html
+++ b/src/main/resources/templates/fragments/serviceui.html
@@ -12,7 +12,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div th:fragment="serviceUI" th:if="${registeredService}" id="serviceui" class="mb-4 service-ui">
+        <div th:fragment="serviceUI" th:if="${registeredService}" id="serviceui" class="mb-4 service-ui text-center">
             <img id="servicelogo" class="service-ui-logo" th:src="${registeredService.logo} ? ${registeredService.logo} : @{'images/osf-logo.png'}" />
             <div id="servicedesc" class="ml-2 service-ui-info">
                 <h1 class="service-ui-name" th:if="${registeredService.name}" th:text="${registeredService.name}"></h1>

--- a/src/main/resources/templates/fragments/submitbutton.html
+++ b/src/main/resources/templates/fragments/submitbutton.html
@@ -11,55 +11,51 @@
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div class="form-button" th:fragment="submitButton (buttonCustomization, messageKey)">
-
-        <button
-                class="mdc-button mdc-button--raised"
-                th:classappend="${buttonCustomization}"
-                th:if="${recaptchaSiteKey == null}"
-                name="submit"
-                accesskey="l"
-                type="submit">
-            <span class="mdc-button__label" th:text="#{${messageKey}}">Login</span>
-        </button>
-
-        <span th:unless="${recaptchaSiteKey == null}" th:switch="${recaptchaVersion}">
-            <span th:case="'v2'" th:remove="tag">
-                <button th:unless="${recaptchaSiteKey != null AND recaptchaInvisible != null AND recaptchaInvisible}"
-                        class="mdc-button mdc-button--raised"
-                        name="submit"
-                        accesskey="l"
-                        type="submit"
-                        value="Login3">
-                    <span class="mdc-button__label" th:text="#{${messageKey}}">Login</span>
-                </button>
-                <button th:if="${recaptchaSiteKey != null AND recaptchaInvisible != null AND recaptchaInvisible}"
-                        class="mdc-button mdc-button--raised"
-                        th:attr="data-sitekey=${recaptchaSiteKey}, data-badge=${recaptchaPosition}"
-                        data-callback="onRecaptchaV2Submit"
-                        name="submitBtn"
-                        accesskey="l">
-                    <span class="mdc-button__label" th:text="#{${messageKey}}" ></span>
-                </button>
+    <main role="main" class="container mt-3 mb-3">
+        <div class="form-button" th:fragment="submitButton (buttonCustomization, messageKey)">
+            <button
+                    class="mdc-button mdc-button--raised"
+                    th:classappend="${buttonCustomization}"
+                    th:if="${recaptchaSiteKey == null}"
+                    name="submit"
+                    accesskey="l"
+                    type="submit">
+                <span class="mdc-button__label" th:text="#{${messageKey}}">Login</span>
+            </button>
+            <span th:unless="${recaptchaSiteKey == null}" th:switch="${recaptchaVersion}">
+                <span th:case="'v2'" th:remove="tag">
+                    <button th:unless="${recaptchaSiteKey != null AND recaptchaInvisible != null AND recaptchaInvisible}"
+                            class="mdc-button mdc-button--raised"
+                            name="submit"
+                            accesskey="l"
+                            type="submit"
+                            value="Login3">
+                        <span class="mdc-button__label" th:text="#{${messageKey}}">Login</span>
+                    </button>
+                    <button th:if="${recaptchaSiteKey != null AND recaptchaInvisible != null AND recaptchaInvisible}"
+                            class="mdc-button mdc-button--raised"
+                            th:attr="data-sitekey=${recaptchaSiteKey}, data-badge=${recaptchaPosition}"
+                            data-callback="onRecaptchaV2Submit"
+                            name="submitBtn"
+                            accesskey="l">
+                        <span class="mdc-button__label" th:text="#{${messageKey}}" ></span>
+                    </button>
+                </span>
+                <span th:case="'v3'" th:remove="tag">
+                    <button class="mdc-button mdc-button--raised"
+                            th:if="${recaptchaSiteKey != null}"
+                            name="submit"
+                            th:attr="data-sitekey=${recaptchaSiteKey}"
+                            accesskey="l"
+                            th:value="#{screen.welcome.button.login}"
+                            type="submit"
+                            value="Login3">
+                        <span class="mdc-button__label" th:text="#{${messageKey}}" />
+                    </button>
+                </span>
             </span>
-
-            <span th:case="'v3'" th:remove="tag">
-                <button class="mdc-button mdc-button--raised"
-                        th:if="${recaptchaSiteKey != null}"
-                        name="submit"
-                        th:attr="data-sitekey=${recaptchaSiteKey}"
-                        accesskey="l"
-                        th:value="#{screen.welcome.button.login}"
-                        type="submit"
-                        value="Login3">
-                    <span class="mdc-button__label" th:text="#{${messageKey}}" />
-                </button>
-             </span>
-        </span>
-    </div>
-
-</main>
+        </div>
+    </main>
 </body>
 
 </html>

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -114,7 +114,7 @@
                     <div th:replace="fragments/submitbutton :: submitButton (buttonCustomization='button-osf-green', messageKey='screen.twofactor.button.verify')" />
 
                     <div class="form-button">
-                        <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.home.url})}">
+                        <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=#{osf.logout.url})}">
                             <span class="mdc-button__label" th:utext="#{screen.twofactor.button.cancel}"></span>
                         </a>
                     </div>

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -23,7 +23,7 @@
 
             <h3 class="text-center text-with-mdi">
                 <i class="mdi mdi-cellphone mdi-before-text"></i>
-                <span th:utext="#{screen.twofactor.instructions}"></span>
+                <span th:utext="#{screen.twofactor.instructions.top}"></span>
             </h3>
 
             <div class="form-wrapper">
@@ -123,8 +123,8 @@
 
                 <hr class="my-4" />
 
-                <div>
-                    <p>Open the two-factor authentication app on your device to view your authentication code and verify your identity.</p>
+                <div class="text-without-mdi">
+                    <p th:utext="#{screen.twofactor.instructions.bottom}"></p>
                 </div>
 
                 <script type="text/javascript" th:inline="javascript">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -19,24 +19,24 @@
 </head>
 
 <body>
-<script th:replace="fragments/scripts" />
+    <script th:replace="fragments/scripts"></script>
 
-<div th:replace="fragments/header :: header">
-    <a href="fragments/header.html"></a>
-</div>
+    <div th:replace="fragments/header :: header">
+        <a href="fragments/header.html"></a>
+    </div>
 
-<div class="mdc-drawer-scrim"></div>
+    <div class="mdc-drawer-scrim"></div>
 
-<div class="mdc-drawer-app-content mdc-top-app-bar--fixed-adjust d-flex justify-content-center">
-    <main role="main" id="main-content" class="container-lg py-4">
-        <div layout:fragment="content" id="content">
-        </div>
-    </main>
-</div>
+    <div class="mdc-drawer-app-content mdc-top-app-bar--fixed-adjust d-flex justify-content-center">
+        <main role="main" id="main-content" class="container-lg py-4">
+            <div layout:fragment="content" id="content">
+            </div>
+        </main>
+    </div>
 
-<div th:replace="fragments/footer :: footer">
-    <a href="fragments/footer.html"></a>
-</div>
-
+    <div th:replace="fragments/footer :: footer">
+        <a href="fragments/footer.html"></a>
+    </div>
 </body>
+
 </html>


### PR DESCRIPTION
## Ticket

Supports [ENG-2345](https://openscience.atlassian.net/browse/ENG-2345)

## Purpose

* Further customize more error pages
* Improve responsive experience on all error pages

## Changes

* Updated service error and CAS error page (minor)
* Rewrote generic logout page (minor)
* Rewrote generic login success page (major)
* Fixed OSF logout URL in logout / back-to-OSF buttons 
* Fixed HTML style for a few templates
* Rewrote footer and header
* Improved UI / UX on wide and narrow (width) screens and on short (height) screen experience

### New Pages with Customization

<img width="1503" alt="new-pages-1" src="https://user-images.githubusercontent.com/3750414/97665384-ac47ec80-1a51-11eb-83d2-a1e1e6ded9d5.png">

![new-pages-2](https://user-images.githubusercontent.com/3750414/97665395-b0740a00-1a51-11eb-9f67-afd2a0605158.png)


### How newCAS Looks on Different Device / Screen Sizes

* Phone with small screen

<img width="340" alt="newCAS-mainLogin-mobileSmall" src="https://user-images.githubusercontent.com/3750414/97663317-9f29fe00-1a4f-11eb-9bda-100f36a273b8.png">

* Phone with large screen

<img width="431" alt="newCAS-mainLogin-mobileLarge" src="https://user-images.githubusercontent.com/3750414/97663318-a05b2b00-1a4f-11eb-9645-2b58279008f4.png">

* Tablet vertical

<img width="790" alt="newCAS-mainLogin-tabletVertical" src="https://user-images.githubusercontent.com/3750414/97663323-a3561b80-1a4f-11eb-836d-f62b76ea9132.png">

* Tablet horizontal

<img width="1047" alt="newCAS-mainLogin-tabletHorizontal" src="https://user-images.githubusercontent.com/3750414/97663320-a18c5800-1a4f-11eb-8afe-e6a6a5f7089c.png">

* 720p

<img width="1321" alt="newCAS-mainLogin-720p" src="https://user-images.githubusercontent.com/3750414/97663325-a3eeb200-1a4f-11eb-8804-16a746934c82.png">

* 1080p

<img width="1960" alt="newCAS-mainLogin-1080p" src="https://user-images.githubusercontent.com/3750414/97663326-a3eeb200-1a4f-11eb-80d1-e667eaf92a85.png">

* 1440p

<img width="2466" alt="newCAS-mainLogin-1440p" src="https://user-images.githubusercontent.com/3750414/97663329-a4874880-1a4f-11eb-8b82-8b8c5126ba39.png">

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
