### PR TITLE
[No Ticket] Web Flow Pre-init Action

### DIFF
--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -71,6 +71,7 @@ cas.logout.remove-descendant-tickets=false
 #
 cas.authn.osf-url.home=https://{{ .Values.osfDomain }}/
 cas.authn.osf-url.dashboard=https://{{ .Values.osfDomain }}/dashboard/
+cas.authn.osf-url.login-with-next=https://{{ .Values.osfDomain }}/login?next=
 cas.authn.osf-url.logout=https://{{ .Values.osfDomain }}/logout/
 cas.authn.osf-url.resend-confirmation=https://{{ .Values.osfDomain }}/resend/
 cas.authn.osf-url.forgot-password=https://{{ .Values.osfDomain }}/forgotpassword/

--- a/etc/cas/config/local/cas-local.properties
+++ b/etc/cas/config/local/cas-local.properties
@@ -72,6 +72,7 @@ cas.logout.remove-descendant-tickets=false
 #
 cas.authn.osf-url.home=http://localhost:5000/
 cas.authn.osf-url.dashboard=http://localhost:5000/dashboard/
+cas.authn.osf-url.login-with-next=http://localhost:5000/login?next=
 cas.authn.osf-url.logout=http://localhost:5000/logout/
 cas.authn.osf-url.resend-confirmation=http://localhost:5000/resend/
 cas.authn.osf-url.forgot-password=http://localhost:5000/forgotpassword/

--- a/src/main/java/io/cos/cas/osf/configuration/model/OsfUrlProperties.java
+++ b/src/main/java/io/cos/cas/osf/configuration/model/OsfUrlProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This is {@link OsfUrlProperties}.
@@ -38,6 +40,11 @@ public class OsfUrlProperties implements Serializable {
      * OSF sign-up page URL.
      */
     private String register;
+
+    /**
+     * OSF login endpoint with "?next=".
+     */
+    private String loginWithNext;
 
     /**
      * OSF logout endpoint URL.
@@ -88,4 +95,11 @@ public class OsfUrlProperties implements Serializable {
      * OSF / COS donation page URL.
      */
     private String donate;
+
+    /**
+     * Build the default service URL using OSF login endpoint with OSF home page as destination.
+     */
+    public String constructDefaultServiceUrl() {
+        return loginWithNext + URLEncoder.encode(home, StandardCharsets.UTF_8);
+    }
 }

--- a/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
@@ -3,6 +3,7 @@ package io.cos.cas.osf.web.config;
 import io.cos.cas.osf.dao.JpaOsfDao;
 import io.cos.cas.osf.web.flow.login.OsfDefaultLoginPreparationAction;
 import io.cos.cas.osf.web.flow.login.OsfInstitutionLoginPreparationAction;
+import io.cos.cas.osf.web.flow.login.OsfCasPreInitialFlowSetupAction;
 import io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction;
 
 import org.apereo.cas.CentralAuthenticationService;
@@ -22,7 +23,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.webflow.execution.Action;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -48,7 +48,6 @@ public class OsfCasSupportActionsConfiguration extends CasSupportActionsConfigur
     @Qualifier("initialAuthenticationAttemptWebflowEventResolver")
     private ObjectProvider<CasDelegatingWebflowEventResolver> initialAuthenticationAttemptWebflowEventResolver;
 
-
     @Autowired
     @Qualifier("adaptiveAuthenticationPolicy")
     private ObjectProvider<AdaptiveAuthenticationPolicy> adaptiveAuthenticationPolicy;
@@ -59,6 +58,16 @@ public class OsfCasSupportActionsConfiguration extends CasSupportActionsConfigur
 
     @Autowired
     private ObjectProvider<JpaOsfDao> jpaOsfDao;
+
+    /**
+     * Bean configuration for {@link OsfCasPreInitialFlowSetupAction}.
+     *
+     * @return the initialized action
+     */
+    @Bean
+    public Action osfCasPreInitialFlowSetupAction() {
+        return new OsfCasPreInitialFlowSetupAction(casProperties.getAuthn().getOsfUrl());
+    }
 
     /**
      * Bean configuration for {@link OsfPrincipalFromNonInteractiveCredentialsAction}.

--- a/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasWebflowContextConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasWebflowContextConfiguration.java
@@ -1,6 +1,7 @@
 package io.cos.cas.osf.web.flow.config;
 
 import io.cos.cas.osf.web.flow.configurer.OsfCasLoginWebflowConfigurer;
+import io.cos.cas.osf.web.flow.configurer.OsfCasLogoutWebFlowConfigurer;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
@@ -45,5 +46,17 @@ public class OsfCasWebflowContextConfiguration extends CasWebflowContextConfigur
         osfCasLoginWebflowConfigurer.setLogoutFlowDefinitionRegistry(logoutFlowRegistry());
         osfCasLoginWebflowConfigurer.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return osfCasLoginWebflowConfigurer;
+    }
+
+    @Override
+    @Bean
+    @Order(DEFAULT_WEB_FLOW_CONFIGURER_ORDER)
+    @Lazy(false)
+    public CasWebflowConfigurer defaultLogoutWebflowConfigurer() {
+        OsfCasLogoutWebFlowConfigurer osfCasLogoutWebFlowConfigurer
+                = new OsfCasLogoutWebFlowConfigurer(builder(), loginFlowRegistry(), applicationContext, casProperties);
+        osfCasLogoutWebFlowConfigurer.setLogoutFlowDefinitionRegistry(logoutFlowRegistry());
+        osfCasLogoutWebFlowConfigurer.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return osfCasLogoutWebFlowConfigurer;
     }
 }

--- a/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
@@ -26,6 +26,7 @@ import org.apereo.cas.web.flow.configurer.DefaultLoginWebflowConfigurer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
+import org.springframework.webflow.engine.ActionList;
 import org.springframework.webflow.engine.ActionState;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.History;
@@ -64,6 +65,13 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
             final CasConfigurationProperties casProperties
     ) {
         super(flowBuilderServices, flowDefinitionRegistry, applicationContext, casProperties);
+    }
+
+    @Override
+    protected void createInitialFlowActions(final Flow flow) {
+        final ActionList startActionList = flow.getStartActionList();
+        startActionList.add(createEvaluateAction(OsfCasWebflowConstants.ACTION_ID_OSF_PRE_INITIAL_FLOW_SETUP));
+        super.createInitialFlowActions(flow);
     }
 
     @Override
@@ -438,5 +446,4 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SSO_INIT
         );
     }
-
 }

--- a/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
@@ -81,6 +81,7 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
         createTwoFactorLoginFormView(flow);
         createInstitutionLoginView(flow);
         createOrcidLoginAutoRedirectView(flow);
+        createDefaultServiceLoginAutoRedirectView(flow);
         createOsfCasAuthenticationExceptionViewStates(flow);
     }
 
@@ -326,6 +327,11 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
         );
         createTransitionForState(
                 action,
+                OsfCasWebflowConstants.TRANSITION_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT,
+                OsfCasWebflowConstants.VIEW_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT
+        );
+        createTransitionForState(
+                action,
                 CasWebflowConstants.TRANSITION_ID_ERROR,
                 CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM
         );
@@ -431,6 +437,19 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
             flow,
             OsfCasWebflowConstants.VIEW_ID_ORCID_LOGIN_AUTO_REDIRECT,
             OsfCasWebflowConstants.VIEW_ID_ORCID_LOGIN_AUTO_REDIRECT
+        );
+    }
+
+    /**
+     * Create the ORCiD login auto-redirect view to support the OSF feature "sign-up via ORCiD".
+     *
+     * @param flow the flow
+     */
+    protected void createDefaultServiceLoginAutoRedirectView(final Flow flow) {
+        createViewState(
+                flow,
+                OsfCasWebflowConstants.VIEW_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT,
+                OsfCasWebflowConstants.VIEW_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT
         );
     }
 

--- a/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLogoutWebFlowConfigurer.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLogoutWebFlowConfigurer.java
@@ -1,0 +1,49 @@
+package io.cos.cas.osf.web.flow.configurer;
+
+import io.cos.cas.osf.web.flow.support.OsfCasWebflowConstants;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.web.flow.configurer.DefaultLogoutWebflowConfigurer;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
+import org.springframework.webflow.engine.ActionList;
+import org.springframework.webflow.engine.Flow;
+import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
+
+/**
+ * This is {@link OsfCasLogoutWebFlowConfigurer}.
+ *
+ * @author Longze Chen
+ * @since 20.2.0
+ */
+public class OsfCasLogoutWebFlowConfigurer extends DefaultLogoutWebflowConfigurer {
+
+    public OsfCasLogoutWebFlowConfigurer(
+            final FlowBuilderServices flowBuilderServices,
+            final FlowDefinitionRegistry flowDefinitionRegistry,
+            final ConfigurableApplicationContext applicationContext,
+            final CasConfigurationProperties casProperties
+    ) {
+        super(flowBuilderServices, flowDefinitionRegistry, applicationContext, casProperties);
+    }
+
+    @Override
+    protected void doInitialize() {
+        final Flow flow = getLogoutFlow();
+        if (flow != null) {
+            createInitialFlowActions(flow);
+        }
+        super.doInitialize();
+    }
+
+    /**
+     * Create initial flow actions similar to {@link OsfCasLoginWebflowConfigurer#createInitialFlowActions(Flow)}.
+     *
+     * @param flow the flow
+     */
+    protected void createInitialFlowActions(final Flow flow) {
+        final ActionList startActionList = flow.getStartActionList();
+        startActionList.add(createEvaluateAction(OsfCasWebflowConstants.ACTION_ID_OSF_PRE_INITIAL_FLOW_SETUP));
+    }
+}

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfAbstractLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfAbstractLoginPreparationAction.java
@@ -8,6 +8,10 @@ import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * This is {@link OsfAbstractLoginPreparationAction}.
  *
@@ -38,6 +42,10 @@ public abstract class OsfAbstractLoginPreparationAction extends AbstractAuthenti
     protected static final String PARAMETER_ORCID_REDIRECT = "redirectOrcid";
 
     protected static final String PARAMETER_ORCID_REDIRECT_VALUE = "true";
+
+    protected static final String PARAMETER_ERROR_SOURCE = "errorSource";
+
+    protected static final List<String> EXPECTED_ERROR_CODES = new LinkedList<>(Arrays.asList("401", "403", "404", "405", "423"));
 
     public OsfAbstractLoginPreparationAction(
             final CasDelegatingWebflowEventResolver initialAuthenticationAttemptWebflowEventResolver,

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfCasPreInitialFlowSetupAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfCasPreInitialFlowSetupAction.java
@@ -2,6 +2,7 @@ package io.cos.cas.osf.web.flow.login;
 
 import io.cos.cas.osf.configuration.model.OsfUrlProperties;
 
+import io.cos.cas.osf.web.flow.support.OsfCasWebflowConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,17 +23,16 @@ import java.util.Optional;
 @Slf4j
 public class OsfCasPreInitialFlowSetupAction extends AbstractAction {
 
-    private static final String OSF_URL_FLOW_PARAMETER = "osfUrl";
-
     @NotNull
     private final OsfUrlProperties osfUrlProperties;
 
     @Override
     protected Event doExecute(final RequestContext context) {
-        OsfUrlProperties osfUrl = Optional.of(context).map(requestContext
-                -> (OsfUrlProperties) requestContext.getFlowScope().get(OSF_URL_FLOW_PARAMETER)).orElse(null);
+        final OsfUrlProperties osfUrl = Optional.of(context).map(
+                requestContext -> (OsfUrlProperties) requestContext.getFlowScope().get(OsfCasWebflowConstants.FLOW_PARAMETER_OSF_URL)
+        ).orElse(null);
         if (osfUrl == null) {
-            context.getFlowScope().put(OSF_URL_FLOW_PARAMETER, osfUrlProperties);
+            context.getFlowScope().put(OsfCasWebflowConstants.FLOW_PARAMETER_OSF_URL, osfUrlProperties);
         }
         return success();
     }

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfCasPreInitialFlowSetupAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfCasPreInitialFlowSetupAction.java
@@ -1,0 +1,39 @@
+package io.cos.cas.osf.web.flow.login;
+
+import io.cos.cas.osf.configuration.model.OsfUrlProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+/**
+ * This is {@link OsfCasPreInitialFlowSetupAction}.
+ *
+ * @author Longze Chen
+ * @since 20.2.0
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class OsfCasPreInitialFlowSetupAction extends AbstractAction {
+
+    private static final String OSF_URL_FLOW_PARAMETER = "osfUrl";
+
+    @NotNull
+    private final OsfUrlProperties osfUrlProperties;
+
+    @Override
+    protected Event doExecute(final RequestContext context) {
+        OsfUrlProperties osfUrl = Optional.of(context).map(requestContext
+                -> (OsfUrlProperties) requestContext.getFlowScope().get(OSF_URL_FLOW_PARAMETER)).orElse(null);
+        if (osfUrl == null) {
+            context.getFlowScope().put(OSF_URL_FLOW_PARAMETER, osfUrlProperties);
+        }
+        return success();
+    }
+}

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -80,7 +80,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * This is {@link OsfPrincipalFromNonInteractiveCredentialsAction}.
@@ -265,12 +264,6 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
 
     @Override
     protected Event doPreExecute(final RequestContext context) throws Exception {
-        // Put server-specific OSF URLs into the flow scope
-        OsfUrlProperties osfUrl = Optional.of(context).map(requestContext
-                -> (OsfUrlProperties) requestContext.getFlowScope().get(OSF_URL_FLOW_PARAMETER)).orElse(null);
-        if (osfUrl == null) {
-            context.getFlowScope().put(OSF_URL_FLOW_PARAMETER, osfUrlProperties);
-        }
         // super.doPreExecute() calls constructCredentialsFromRequest() whose exception must be caught and returned as a flow event
         try {
             return super.doPreExecute(context);

--- a/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
@@ -10,6 +10,8 @@ package io.cos.cas.osf.web.flow.support;
 
 public interface OsfCasWebflowConstants {
 
+    String ACTION_ID_OSF_PRE_INITIAL_FLOW_SETUP = "osfCasPreInitialFlowSetupAction";
+
     String ACTION_ID_OSF_DEFAULT_LOGIN_CHECK = "osfDefaultLoginCheckAction";
 
     String STATE_ID_OSF_DEFAULT_LOGIN_CHECK = "osfDefaultLoginCheck";

--- a/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
@@ -2,7 +2,7 @@ package io.cos.cas.osf.web.flow.support;
 
 /**
  * This is {@link OsfCasWebflowConstants}, which expands the default {@link org.apereo.cas.web.flow.CasWebflowConstants}
- * interface by adding OSF CAS customized action, state and view IDs.
+ * interface by adding OSF CAS customized action, state, transition and view IDs as well as names web flow parameters.
  *
  * @author Longze Chen
  * @since 20.0.0
@@ -10,27 +10,37 @@ package io.cos.cas.osf.web.flow.support;
 
 public interface OsfCasWebflowConstants {
 
+    String FLOW_PARAMETER_OSF_URL = "osfUrl";
+
     String ACTION_ID_OSF_PRE_INITIAL_FLOW_SETUP = "osfCasPreInitialFlowSetupAction";
+
+    String ACTION_ID_OSF_NON_INTERACTIVE_AUTHENTICATION_CHECK = "osfNonInteractiveAuthenticationCheckAction";
 
     String ACTION_ID_OSF_DEFAULT_LOGIN_CHECK = "osfDefaultLoginCheckAction";
 
-    String STATE_ID_OSF_DEFAULT_LOGIN_CHECK = "osfDefaultLoginCheck";
-
-    String TRANSITION_ID_USERNAME_PASSWORD_LOGIN = "continueToUsernamePasswordLogin";
-
     String ACTION_ID_OSF_INSTITUTION_LOGIN_CHECK = "osfInstitutionLoginCheckAction";
 
-    String STATE_ID_OSF_INSTITUTION_LOGIN_CHECK = "osfInstitutionLoginCheck";
+    String TRANSITION_ID_USERNAME_PASSWORD_LOGIN = "continueToUsernamePasswordLogin";
 
     String TRANSITION_ID_INSTITUTION_LOGIN = "switchToInstitutionLogin";
 
     String TRANSITION_ID_ORCID_LOGIN_AUTO_REDIRECT = "autoRedirectToOrcidLogin";
 
-    String VIEW_ID_ORCID_LOGIN_AUTO_REDIRECT = "casAutoRedirectToOrcidLoginView";
-
-    String ACTION_ID_OSF_NON_INTERACTIVE_AUTHENTICATION_CHECK = "osfNonInteractiveAuthenticationCheckAction";
+    String TRANSITION_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT = "autoRedirectToDefaultServiceLogin";
 
     String STATE_ID_OSF_NON_INTERACTIVE_AUTHENTICATION_CHECK = "osfNonInteractiveAuthenticationCheck";
+
+    String STATE_ID_OSF_DEFAULT_LOGIN_CHECK = "osfDefaultLoginCheck";
+
+    String STATE_ID_OSF_INSTITUTION_LOGIN_CHECK = "osfInstitutionLoginCheck";
+
+    String VIEW_ID_INSTITUTION_SSO_INIT = "casInstitutionLoginView";
+
+    String VIEW_ID_ORCID_LOGIN_AUTO_REDIRECT = "casAutoRedirectToOrcidLoginView";
+
+    String VIEW_ID_DEFAULT_SERVICE_LOGIN_AUTO_REDIRECT = "casAutoRedirectToDefaultServiceLoginView";
+
+    String VIEW_ID_ONE_TIME_PASSWORD_REQUIRED = "casTwoFactorLoginView";
 
     String VIEW_ID_ACCOUNT_NOT_CONFIRMED_OSF = "casAccountNotConfirmedOsfView";
 
@@ -39,10 +49,6 @@ public interface OsfCasWebflowConstants {
     String VIEW_ID_INVALID_USER_STATUS = "casInvalidUserStatusView";
 
     String VIEW_ID_INVALID_VERIFICATION_KEY = "casInvalidVerificationKeyView";
-
-    String VIEW_ID_ONE_TIME_PASSWORD_REQUIRED = "casTwoFactorLoginView";
-
-    String VIEW_ID_INSTITUTION_SSO_INIT = "casInstitutionLoginView";
 
     String VIEW_ID_INSTITUTION_SSO_FAILED = "casInstitutionSsoFailedView";
 }

--- a/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
+++ b/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
@@ -26,7 +26,13 @@ public class OsfCasLoginContext implements Serializable  {
 
     private static final long serialVersionUID = 7523144720609509742L;
 
-    private String serviceUrl;
+    /**
+     * The encoded service URL provided by the "service=" query param in the request URL.
+     *
+     * This attribute is deprecated and should be removed since 1) ThymeLeaf handles URL building elegantly in the template and 2) both of
+     * the flow parameters "service.originalUrl" and "originalUrl" stores the current service information.
+     */
+    private String encodedServiceUrl;
 
     private String handleErrorName;
 
@@ -38,18 +44,31 @@ public class OsfCasLoginContext implements Serializable  {
 
     private String orcidLoginUrl;
 
+    private boolean defaultService;
+
+    /**
+     * The default service URL that uses OSF login endpoint with OSF home as destination.
+     *
+     * e.g. http(s)://[OSF Domain]/login?next=[encoded version of http(s)://[OSF Domain]/]
+     */
+    private String defaultServiceUrl;
+
     public OsfCasLoginContext (
-            final String serviceUrl,
+            final String encodedServiceUrl,
             final boolean institutionLogin,
             final String institutionId,
             final boolean orcidRedirect,
-            final String orcidLoginUrl
+            final String orcidLoginUrl,
+            final boolean defaultService,
+            final String defaultServiceUrl
     ) {
-        this.serviceUrl = serviceUrl;
+        this.encodedServiceUrl = encodedServiceUrl;
         this.handleErrorName = null;
         this.institutionLogin = institutionLogin;
         this.institutionId = institutionId;
         this.orcidRedirect = orcidRedirect;
         this.orcidLoginUrl = orcidLoginUrl;
+        this.defaultService = defaultService;
+        this.defaultServiceUrl = defaultServiceUrl;
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -545,6 +545,7 @@ screen.pm.button.backtoosf=Back to OSF
 screen.delegation.button.orcid=Sign in with ORCiD
 screen.delegation.button.institution=Sign in through institution
 screen.delegation.heading.orcidredirect=Redirecting to ORCiD
+screen.flowless.heading.defaultserviceredirect=Redirecting to OSF login
 #
 # Two factor and login form submission
 #

--- a/src/main/resources/templates/casAutoRedirectToDefaultServiceLoginView.html
+++ b/src/main/resources/templates/casAutoRedirectToDefaultServiceLoginView.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head th:with="defaultServiceLoginUrl=@{/login(service=${osfCasLoginContext.defaultServiceUrl})}">
+        <!-- When this template is rendered, both ${osfCasLoginContext.defaultSerivceUrl}
+             and #{screen.flowless.heading.defaultserviceredirect} are guranteed to exist. -->
+        <meta http-equiv="refresh" th:content="${'0; url=' + defaultServiceLoginUrl}" />
+        <title th:text="#{screen.flowless.heading.defaultserviceredirect}"></title>
+    </head>
+</html>

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{screen.error.page.title.accessdenied}">Error - 401</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+<main role="main" class="container mt-3 mb-3">
+    <div layout:fragment="content"  class="mdc-card p-4 w-lg-66 m-auto">
+        <h2 th:utext="#{screen.error.page.accessdenied}">Access Denied</h2>
+        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+        <a class="mdc-button mdc-button-raised" th:href="@{/login}">
+            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+        </a>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{screen.error.page.title.accessdenied}">Error - 401</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content"  class="mdc-card p-4 w-lg-66 m-auto">
-        <h2 th:utext="#{screen.error.page.accessdenied}">Access Denied</h2>
-        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
-        <a class="mdc-button mdc-button-raised" th:href="@{/login}">
-            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
-        </a>
-    </div>
-</main>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+            <h2 th:utext="#{screen.error.page.accessdenied}">Access Denied</h2>
+            <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+            <a class="mdc-button mdc-button-raised" th:href="@{/login(errorSource=401)}">
+                <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+            </a>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{screen.error.page.title.permissiondenied}">Error - Permission Denied</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+<main role="main" class="container mt-3 mb-3">
+    <div layout:fragment="content"  class="mdc-card p-4 w-lg-66 m-auto">
+        <h2 th:utext="#{screen.error.page.authdenied}">Authorization Denied</h2>
+        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+        <a class="mdc-button" th:href="@{/login}">
+            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+        </a>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{screen.error.page.title.permissiondenied}">Error - Permission Denied</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content"  class="mdc-card p-4 w-lg-66 m-auto">
-        <h2 th:utext="#{screen.error.page.authdenied}">Authorization Denied</h2>
-        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
-        <a class="mdc-button" th:href="@{/login}">
-            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
-        </a>
-    </div>
-</main>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+            <h2 th:utext="#{screen.error.page.authdenied}">Authorization Denied</h2>
+            <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+            <a class="mdc-button" th:href="@{/login(errorSource=403)}">
+                <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+            </a>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{screen.error.page.title.pagenotfound}">Error - Page Not Found</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+<main role="main" class="container mt-3 mb-3">
+    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+        <h2 th:utext="#{screen.error.page.notfound}">Page Not Found</h2>
+        <p th:utext="#{screen.error.page.doesnotexist}">The page you are attempting to access does not exist at the
+            moment.</p>
+        <a class="mdc-button" th:href="@{/login}">
+            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+        </a>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,25 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{screen.error.page.title.pagenotfound}">Error - Page Not Found</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
-        <h2 th:utext="#{screen.error.page.notfound}">Page Not Found</h2>
-        <p th:utext="#{screen.error.page.doesnotexist}">The page you are attempting to access does not exist at the
-            moment.</p>
-        <a class="mdc-button" th:href="@{/login}">
-            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
-        </a>
-    </div>
-</main>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+            <h2 th:utext="#{screen.error.page.notfound}">Page Not Found</h2>
+            <p th:utext="#{screen.error.page.doesnotexist}">The page you are attempting to access does not exist at the moment.</p>
+            <a class="mdc-button" th:href="@{/login(errorSource=404)}">
+                <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+            </a>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{screen.error.page.title.requestunsupported}">Error - Unsupported Request</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+<main role="main" class="container mt-3 mb-3">
+    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+        <h2 th:utext="#{screen.error.page.requestunsupported}">The request type or syntax is not supported.</h2>
+        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+        <a class="mdc-button" th:href="@{/login}">
+            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+        </a>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -1,23 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{screen.error.page.title.requestunsupported}">Error - Unsupported Request</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
-        <h2 th:utext="#{screen.error.page.requestunsupported}">The request type or syntax is not supported.</h2>
-        <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
-        <a class="mdc-button" th:href="@{/login}">
-            <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
-        </a>
-    </div>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+            <h2 th:utext="#{screen.error.page.requestunsupported}">The request type or syntax is not supported.</h2>
+            <p th:utext="#{screen.error.page.permissiondenied}">You do not have permission to view this page.</p>
+            <a class="mdc-button" th:href="@{/login(errorSource=405)}">
+                <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+            </a>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{screen.error.page.title.blocked}">Error - Permission Denied</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+<main role="main" class="container mt-3 mb-3">
+    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+        <h2 th:utext="#{screen.blocked.header}">Access Denied</h2>
+        <p th:utext="#{screen.blocked.message}">You've entered the wrong password for the user too many times.
+            You've been throttled.</p>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -1,22 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
 
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{screen.error.page.title.blocked}">Error - Permission Denied</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
-        <h2 th:utext="#{screen.blocked.header}">Access Denied</h2>
-        <p th:utext="#{screen.blocked.message}">You've entered the wrong password for the user too many times.
-            You've been throttled.</p>
-    </div>
-</main>
+    <main role="main" class="container mt-3 mb-3">
+        <div layout:fragment="content" class="mdc-card p-4 w-lg-66 m-auto">
+            <h2 th:utext="#{screen.blocked.header}">Access Denied</h2>
+            <p th:utext="#{screen.blocked.message}">You've entered the wrong password for the user too many times. You've been throttled.</p>
+            <a class="mdc-button" th:href="@{/login(errorSource=423)}">
+                <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}">Login Again</span>
+            </a>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/src/main/resources/templates/fragments/headerflowless.html
+++ b/src/main/resources/templates/fragments/headerflowless.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+    <title></title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
+</head>
+
+<body>
+    <div th:fragment="headerflowless">
+        <header id="app-bar" class="mdc-top-app-bar mdc-top-app-bar--fixed mdc-elevation--z4">
+            <nav class="mdc-top-app-bar__row">
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+                </section>
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
+                        <span class="cas-brand mx-auto">
+                            <img class="cas-logo" src="/images/osf-cas-banner-white.png">
+                            <span class="sr-only">OSF CAS</span>
+                        </span>
+                </section>
+                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
+                </section>
+            </nav>
+        </header>
+        <script type="text/javascript">
+            (function (material) {
+                var header = {
+                    init: function () {
+                        header.attachTopbar();
+                        material.autoInit();
+                    },
+                    attachTopbar: function (drawer) {
+                    },
+                    checkCaps: function (ev) {
+                        var s = String.fromCharCode(ev.which);
+                        if (s.toUpperCase() === s && s.toLowerCase() !== s && !ev.shiftKey) {
+                            ev.target.parentElement.classList.add('caps-on');
+                        } else {
+                            ev.target.parentElement.classList.remove('caps-on');
+                        }
+                    },
+                }
+                document.addEventListener('DOMContentLoaded', function () {
+                    header.init();
+                });
+            })(mdc);
+        </script>
+    </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/layoutFlowless.html
+++ b/src/main/resources/templates/layoutFlowless.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title layout:title-pattern="$LAYOUT_TITLE &#124; $CONTENT_TITLE">OSF</title>
+    <link rel="stylesheet" type="text/css" href="../static/css/normalize.css" th:href="@{#{webjars.normalize.css}}" />
+    <link rel="stylesheet" type="text/css" href="../static/css/bootstrap-grid.min.css" th:href="@{#{webjars.bootstrap-grid.css}}" />
+    <link rel="stylesheet" type="text/css" href="../static/css/material-components-web.min.css" th:href="@{#{webjars.material-components.css}}" />
+    <link rel="stylesheet" type="text/css" href="../static/css/mdi-font.css" th:href="@{#{webjars.mdi-font.css}}" />
+    <link rel="stylesheet" type="text/css" href="../static/css/cas.css" th:href="@{${#themes.code('cas.standard.css.file')}}"/>
+    <link rel="icon" th:href="@{/favicon.ico}" type="image/x-icon"/>
+</head>
+
+<body>
+    <script th:replace="fragments/scripts"></script>
+    <div th:replace="fragments/headerflowless :: headerflowless">
+        <a href="fragments/headerflowless.html"></a>
+    </div>
+    <div class="mdc-drawer-scrim"></div>
+    <div class="mdc-drawer-app-content mdc-top-app-bar--fixed-adjust d-flex justify-content-center">
+        <main role="main" id="main-content" class="container-lg py-4">
+            <div layout:fragment="content" id="content">
+            </div>
+        </main>
+    </div>
+    <div th:replace="fragments/footer :: footer">
+        <a href="fragments/footer.html"></a>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Ticket

N/ A

## Purpose

OSF server-specific settings such as OSF URLs need to be configured at the very beginning of the login flow so that ThymeLeaf templates can be rendered correctly across the flow state machine. Previously, it was configured at the start of the non-interactive action where any rendering attempt before it would fail with empty pages rendered. This is fixed now by overriding the flow init process. A pre-init action with what we did in the non-interactive action before is injected onto the top of the start action list.

HTTP 400 errors are not expected during normal authentication and authorization flow between OSF CAS and OSF. Sometimes they do not trigger login or logout flow init and are handled and routed to built-in templates directly by Tomcat. This unfortunately breaks OSF CAS customized fragment templates that relies on web flow init. The fix is to use a flow-less layout and header, then replace the no-service "/login?" href with one with "errorSource=4XX" as query param so that the pre-login check action can handle. Finally, login flow are customized to handle this param and redirect to a new login flow with OSF home as the default service.

## Changes

- [x] Login flow
- [x] Logout flow
- [x] Other routes

## Dev Notes

N / A

## QA Notes

Here is a few example routes to test.

* `404 Not Found`
  * `http://192.168.168.167:8080/pathnotfound`
* login flow with param `errorSource=`
 * `http://192.168.168.167:8080/login?errorSource=404`
* login flow with invalid service
  * `http://192.168.168.167:8080/login?service=http%3A%2F%2Flocalhost%3A5001%2F`
* logout flow without service
  * `http://192.168.168.167:8080/logout`

## Dev-Ops Notes

* Blocked by https://github.com/CenterForOpenScience/osf-cas/pull/11