### PR TITLE
[ENG-2442] Terms of service consent check

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
+++ b/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
@@ -38,6 +38,8 @@ public class OsfPostgresCredential extends RememberMeUsernamePasswordCredential 
 
     public static String AUTHENTICATION_ATTRIBUTE_REMEMBER_ME = "rememberMe";
 
+    public static String AUTHENTICATION_ATTRIBUTE_TOS_CONSENT = "termsOfServiceChecked";
+
     private static String DEFAULT_INSTITUTION_ID = "none";
 
     private static DelegationProtocol DEFAULT_DELEGATION_PROTOCOL = DelegationProtocol.NONE;

--- a/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
+++ b/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
@@ -53,6 +53,11 @@ public class OsfPostgresCredential extends RememberMeUsernamePasswordCredential 
     private String oneTimePassword;
 
     /**
+     * The boolean flag that indicates whether the user has checked the terms of service consent agreement
+     */
+    private boolean termsOfServiceChecked;
+
+    /**
      * The boolean flag that indicates successful delegated authentication if true.
      */
     private boolean remotePrincipal = Boolean.FALSE;

--- a/src/main/java/io/cos/cas/osf/authentication/exception/TermsOfServiceConsentRequiredException.java
+++ b/src/main/java/io/cos/cas/osf/authentication/exception/TermsOfServiceConsentRequiredException.java
@@ -1,0 +1,29 @@
+package io.cos.cas.osf.authentication.exception;
+
+import lombok.NoArgsConstructor;
+
+import javax.security.auth.login.AccountException;
+
+/**
+ * Describes an authentication error condition where a user account needs to agree to OSF's terms of service.
+ *
+ * @author Longze Chen
+ * @since 21.1.0
+ */
+@NoArgsConstructor
+public class TermsOfServiceConsentRequiredException extends AccountException {
+
+    /**
+     * Serialization metadata.
+     */
+    private static final long serialVersionUID = -7702088330316457626L;
+
+    /**
+     * Instantiates a new {@link TermsOfServiceConsentRequiredException}.
+     *
+     * @param msg the msg
+     */
+    public TermsOfServiceConsentRequiredException(final String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
+++ b/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
@@ -3,12 +3,12 @@ package io.cos.cas.osf.authentication.handler.support;
 import io.cos.cas.osf.authentication.credential.OsfPostgresCredential;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedIdpException;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedOsfException;
-import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InvalidOneTimePasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidPasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidUserStatusException;
 import io.cos.cas.osf.authentication.exception.OneTimePasswordRequiredException;
 import io.cos.cas.osf.authentication.exception.InvalidVerificationKeyException;
+import io.cos.cas.osf.authentication.exception.TermsOfServiceConsentRequiredException;
 import io.cos.cas.osf.authentication.support.DelegationProtocol;
 import io.cos.cas.osf.authentication.support.OsfUserStatus;
 import io.cos.cas.osf.authentication.support.OsfUserUtils;
@@ -111,6 +111,7 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
         final String oneTimePassword = credential.getOneTimePassword();
         final String institutionId = credential.getInstitutionId();
         final boolean isRememberMe = credential.isRememberMe();
+        final boolean isTermsOfServiceChecked = credential.isTermsOfServiceChecked();
         final boolean isRemotePrincipal = credential.isRemotePrincipal();
         final DelegationProtocol delegationProtocol = credential.getDelegationProtocol();
 
@@ -167,6 +168,11 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
             } catch (final Exception e) {
                 throw new InvalidOneTimePasswordException("Invalid 2FA TOTP for user [" + username + "] (Type 2)");
             }
+        }
+
+        if (!osfUser.isTermsOfServiceAccepted() && !isTermsOfServiceChecked) {
+            LOGGER.info("Terms of service consent is required for [" + username + "]");
+            throw new TermsOfServiceConsentRequiredException("Terms of service consent is required for [" + username + "]");
         }
 
         if (OsfUserStatus.USER_NOT_CONFIRMED_OSF.equals(userStatus)) {

--- a/src/main/java/io/cos/cas/osf/authentication/metadata/OsfPostgresAuthenticationMetaDataPopulator.java
+++ b/src/main/java/io/cos/cas/osf/authentication/metadata/OsfPostgresAuthenticationMetaDataPopulator.java
@@ -27,16 +27,21 @@ public class OsfPostgresAuthenticationMetaDataPopulator implements Authenticatio
         transaction.getPrimaryCredential().ifPresent(r -> {
             final OsfPostgresCredential credential = (OsfPostgresCredential) r;
             LOGGER.debug(
-                    "Credential is of type [{}], thus adding attributes [{}, {}, {}, {}]",
+                    "Credential is of type [{}], thus adding attributes [{}, {}, {}, {}, {}]",
                     OsfPostgresCredential.class.getSimpleName(),
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME,
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMOTE_PRINCIPAL,
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_DELEGATION_PROTOCOL,
-                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_INSTITUTION_ID
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_INSTITUTION_ID,
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_TOS_CONSENT
             );
             builder.addAttribute(
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME,
                     credential.isRememberMe()
+            );
+            builder.addAttribute(
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_TOS_CONSENT,
+                    credential.isTermsOfServiceChecked()
             );
             builder.addAttribute(
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMOTE_PRINCIPAL,

--- a/src/main/java/io/cos/cas/osf/model/OsfUser.java
+++ b/src/main/java/io/cos/cas/osf/model/OsfUser.java
@@ -63,6 +63,10 @@ public final class OsfUser extends AbstractOsfModel {
     private Date dateConfirmed;
 
     @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "accepted_terms_of_service")
+    private Date dateTermsOfServiceAccepted;
+
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "date_disabled")
     private Date dateDisabled;
 
@@ -84,6 +88,10 @@ public final class OsfUser extends AbstractOsfModel {
 
     public boolean isConfirmed() {
         return dateConfirmed != null;
+    }
+
+    public boolean isTermsOfServiceAccepted() {
+        return dateTermsOfServiceAccepted != null;
     }
 
     public boolean isDisabled() {

--- a/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
@@ -8,6 +8,7 @@ import io.cos.cas.osf.authentication.exception.InvalidPasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidUserStatusException;
 import io.cos.cas.osf.authentication.exception.InvalidVerificationKeyException;
 import io.cos.cas.osf.authentication.exception.OneTimePasswordRequiredException;
+import io.cos.cas.osf.authentication.exception.TermsOfServiceConsentRequiredException;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.web.flow.config.CasCoreWebflowConfiguration;
@@ -47,6 +48,7 @@ public class OsfCasCoreWebflowConfiguration extends CasCoreWebflowConfiguration 
         errors.add(InvalidUserStatusException.class);
         errors.add(InvalidVerificationKeyException.class);
         errors.add(OneTimePasswordRequiredException.class);
+        errors.add(TermsOfServiceConsentRequiredException.class);
 
         // Add built-in exceptions after OSF-specific exceptions since order matters
         errors.addAll(super.handledAuthenticationExceptions());

--- a/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
@@ -42,6 +42,8 @@ public interface OsfCasWebflowConstants {
 
     String VIEW_ID_ONE_TIME_PASSWORD_REQUIRED = "casTwoFactorLoginView";
 
+    String VIEW_ID_TERMS_OF_SERVICE_CONSENT_REQUIRED = "casTermsOfServiceConsentView";
+
     String VIEW_ID_ACCOUNT_NOT_CONFIRMED_OSF = "casAccountNotConfirmedOsfView";
 
     String VIEW_ID_ACCOUNT_NOT_CONFIRMED_IDP = "casAccountNotConfirmedIdPView";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -547,10 +547,11 @@ screen.delegation.button.institution=Sign in through institution
 screen.delegation.heading.orcidredirect=Redirecting to ORCiD
 screen.flowless.heading.defaultserviceredirect=Redirecting to OSF login
 #
-# Two factor and login form submission
+# Two factor login form submission
 #
-cas.twofactor.pagetitle=Sign in
+screen.twofactor.pagetitle=Sign in
 screen.twofactor.instructions.top=Enter your one-time password to finish login
+screen.twofactor.label.email=OSF account email
 screen.twofactor.label.onetimepassword=<span class="accesskey">O</span>ne-time password (6-digit)
 screen.twofactor.label.onetimepassword.accesskey=o
 screen.twofactor.button.verify=Verify

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -587,9 +587,6 @@ screen.institutionlogin.select.errormessage=You must select an institution.
 screen.institutionlogin.button.submit=Sign in
 screen.institutionlogin.osf=Sign in with OSF
 screen.institutionlogin.backtoosf=Exit and go back to OSF
-screen.institutionlogin.consent.checkbox=I have read and agree to the <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use</a> and <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy</a>.
-screen.institutionlogin.consent.errormessage=You must read and agree to the <span style="white-space: nowrap">Terms of Use</span> and <span style="white-space: nowrap">Privacy Policy</span>.
-
 #
 # Generic login and logout success page
 #

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -573,6 +573,7 @@ screen.tosconsent.message.p3=Please read them carefully and contact \
 screen.tosconsent.checkbox.title=I have read and agree to these terms.
 screen.tosconsent.button.agree=Continue
 screen.tosconsent.button.agreewip=One moment please...
+screen.tosconsent.link.cancel=Cancel and go back to OSF
 #
 # Institution login page
 #

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -567,13 +567,13 @@ screen.twofactor.instructions.bottom=Open the two-factor authentication app on y
 screen.tosconsent.pagetitle=Terms of service
 screen.tosconsent.instructions.top=Terms of use and privacy policy
 screen.tosconsent.message.p1=You must read and agree to our \
-  <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use</a> and \
-  <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy</a> \
+  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use"</a> and \
+  <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy"</a> \
   to finish login.
 screen.tosconsent.message.p2=You are seeing this page, either because this is your first-time login to OSF via your \
   institution, or because we have recently updated the terms.
 screen.tosconsent.message.p3=Please read them carefully and contact \
-  <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> should you have any question.
+  <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> should you have any questions.
 screen.tosconsent.checkbox.title=I have read and agree to these terms.
 screen.tosconsent.button.agree=Continue
 screen.tosconsent.link.cancel=Cancel and go back to OSF

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -529,6 +529,10 @@ copyright.cos=<span style="white-space: nowrap">Copyright &copy; 2011 &ndash; 20
 #
 screen.welcome.label.loginwith=Sign in through external identity providers
 #
+# Texts and messages that are shared across all pages
+#
+screen.generic.button.wip = One moment please ...
+#
 # Login page and login form submission
 #
 cas.login.pagetitle=Sign in
@@ -555,7 +559,6 @@ screen.twofactor.label.email=OSF account email
 screen.twofactor.label.onetimepassword=<span class="accesskey">O</span>ne-time password (6-digit)
 screen.twofactor.label.onetimepassword.accesskey=o
 screen.twofactor.button.verify=Verify
-screen.twofactor.button.verifywip=One moment please...
 screen.twofactor.button.cancel=Cancel
 screen.twofactor.instructions.bottom=Open the two-factor authentication app on your device to view your authentication code and verify your identity.
 #
@@ -573,7 +576,6 @@ screen.tosconsent.message.p3=Please read them carefully and contact \
   <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> should you have any question.
 screen.tosconsent.checkbox.title=I have read and agree to these terms.
 screen.tosconsent.button.agree=Continue
-screen.tosconsent.button.agreewip=One moment please...
 screen.tosconsent.link.cancel=Cancel and go back to OSF
 #
 # Institution login page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -558,6 +558,22 @@ screen.twofactor.button.verifywip=One moment please...
 screen.twofactor.button.cancel=Cancel
 screen.twofactor.instructions.bottom=Open the two-factor authentication app on your device to view your authentication code and verify your identity.
 #
+# Terms of service consent check login form submission
+#
+screen.tosconsent.pagetitle=Terms of service
+screen.tosconsent.instructions.top=Terms of use and privacy policy
+screen.tosconsent.message.p1=You must read and agree to our \
+  <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use</a> and \
+  <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy</a> \
+  to finish login.
+screen.tosconsent.message.p2=You are seeing this page, either because this is your first-time login to OSF via your \
+  institution, or because we have recently updated the terms.
+screen.tosconsent.message.p3=Please read them carefully and contact \
+  <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> should you have any question.
+screen.tosconsent.checkbox.title=I have read and agree to these terms.
+screen.tosconsent.button.agree=Continue
+screen.tosconsent.button.agreewip=One moment please...
+#
 # Institution login page
 #
 screen.institutionlogin.pagetitle=Institution SSO
@@ -594,6 +610,7 @@ screen.generic.button.hidedetails=Hide authentication details
 username.required=Email is required.
 password.required=Password is required.
 oneTimePassword.required=One-time password is required.
+termsOfServiceChecked.required=Terms of service consent is required.
 authenticationFailure.AccountDisabledException=This account has been disabled.
 authenticationFailure.AccountNotFoundException=The email or password you entered is incorrect.
 authenticationFailure.AccountNotConfirmedOsfException=The account you tried to log in to has not been confirmed.
@@ -605,6 +622,7 @@ authenticationFailure.InvalidPasswordException=The email or password you entered
 authenticationFailure.InvalidVerificationKeyException=The verification key you entered is incorrect.
 authenticationFailure.InvalidUserStatusException=The account you tried to log in to is not active.
 authenticationFailure.OneTimePasswordRequiredException=
+authenticationFailure.TermsOfServiceConsentRequiredException=
 #
 # Authentication exception messages in stand-alone exception views
 #

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -593,6 +593,7 @@ button.close {
     --cas-theme-osf-green: #357935;
     --cas-theme-osf-blue: #1b6d85;
     --cas-theme-osf-red: #b52b27;
+    --cas-theme-osf-disabled: #EFEFEF;
     --cas-theme-primary: var(--cas-theme-osf-navbar, #263947);
     --cas-theme-danger: var(--cas-theme-osf-red, #b52b27);
     --mdc-theme-primary: var(--cas-theme-primary, #263947);
@@ -809,6 +810,11 @@ body {
 .form-button .button-osf-red,
 .form-button-inline .button-osf-red {
     background-color: var(--cas-theme-osf-red, #b52b27);
+}
+
+.form-button .button-osf-disabled,
+.form-button-inline .button-osf-disabled {
+    background-color: var(--cas-theme-osf-disabled, #EFEFEF);
 }
 
 .login-error-inline {

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -43,16 +43,6 @@
                             <a href="#" onclick="dismissErrorBanner('selecterrormessage'); return false;" class="close">&times;</a>
                         </div>
                     </div>
-                    <div class="instn-consent">
-                        <input type="checkbox" id="consentcheckbox" value="true" tabindex="5" onchange="checkConsent(this)" />
-                        <label for="consentcheckbox" th:utext="#{screen.institutionlogin.consent.checkbox}"></label>
-                    </div>
-                    <div class="instn-login-error">
-                        <div id="consenterrormessage" style="display: none;" class="banner banner-danger banner-dismissible" >
-                            <p class="login-error-inline" th:utext="#{screen.institutionlogin.consent.errormessage}"></p>
-                            <a href="#" onclick="dismissErrorBanner('consenterrormessage'); return false;" class="close">&times;</a>
-                        </div>
-                    </div>
                     <div class="form-button">
                         <button type="button" id="instnsubmit" class="mdc-button mdc-button--raised button-osf-green" name="submit" onclick="institutionLogin()">
                             <span class="mdc-button__label" th:text="#{screen.institutionlogin.button.submit}"></span>
@@ -85,13 +75,8 @@
                     let institutionSelect = document.getElementById("institutionselect");
                     let institutionLoginUrl = institutionSelect.options[institutionSelect.selectedIndex].value;
                     let selectErrorMessage = document.getElementById("selecterrormessage");
-                    let consentCheckbox = document.getElementById('consentcheckbox');
-                    let consentErrorMessage = document.getElementById("consenterrormessage");
                     if (institutionLoginUrl == null || institutionLoginUrl === "") {
                         selectErrorMessage.style.display = "block";
-                        if (consentCheckbox != null) {
-                            consentErrorMessage.style.display = consentCheckbox.checked ? "none" : "block";
-                        }
                         return;
                     }
                     if (institutionLoginUrl === "okstate") {
@@ -112,17 +97,7 @@
                             institutionLoginUrl = institutionLoginUrl.substring(0, lastIndexOfHash);
                         }
                     }
-                    if (consentCheckbox != null && !consentCheckbox.checked) {
-                        consentErrorMessage.style.display = "block";
-                    } else {
-                        window.location = institutionLoginUrl;
-                    }
-                }
-                function checkConsent(consentCheckbox) {
-                    let consentErrorMessage = document.getElementById("consenterrormessage");
-                    if (consentErrorMessage != null) {
-                        consentErrorMessage.style.display = consentCheckbox.checked ? "none" : "block";
-                    }
+                    window.location = institutionLoginUrl;
                 }
                 function checkSelect() {
                     let selectErrorMessage = document.getElementById("selecterrormessage");

--- a/src/main/resources/templates/casTermsOfServiceConsentView.html
+++ b/src/main/resources/templates/casTermsOfServiceConsentView.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+    <title th:text="#{screen.tosconsent.pagetitle}"></title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body class="login mdc-typography">
+    <div layout:fragment="content" class="d-flex justify-content-center">
+
+        <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content"
+            th:classappend="${delegatedAuthenticationProviderConfigurations} OR ${accepttoApplicationId} ? 'w-lg-30' : 'w-lg-50'">
+            <section id="tosloginForm" class="login-section login-form"
+                th:if="${@casThymeleafLoginFormDirector.isLoginFormViewable(#vars)}">
+                <div th:replace="fragments/tosloginform :: tosloginform">
+                    <a href="fragments/tosloginform.html"></a>
+                </div>
+            </section>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/casTwoFactorLoginView.html
+++ b/src/main/resources/templates/casTwoFactorLoginView.html
@@ -5,9 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-    <title th:text="#{cas.twofactor.pagetitle}"></title>
+    <title th:text="#{screen.twofactor.pagetitle}"></title>
     <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
-
 </head>
 
 <body class="login mdc-typography">

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -147,7 +147,7 @@
                         </p>
                     </section>
 
-                    <div th:replace="fragments/submitbutton :: submitButton (buttonCustomization='button-osf-green', messageKey='screen.welcome.button.login')" />
+                    <div th:replace="fragments/submitbutton :: submitButton (buttonDisabled=false, buttonCustomization='button-osf-green', messageKey='screen.welcome.button.login')" />
 
                 </form>
 
@@ -157,13 +157,13 @@
 
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
-                    var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
-                    var j = /*[[@{#{screen.welcome.button.login}}]]*/
-                        /*]]>*/
-                        $(window).on('pageshow', function () {
-                            $(':submit').prop('disabled', false);
-                            $(':submit').attr('value', j);
-                        });
+                        var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
+                        var j = /*[[@{#{screen.welcome.button.login}}]]*/
+                    /*]]>*/
+                    $(window).on('pageshow', function () {
+                        $(':submit').prop('disabled', false);
+                        $(':submit').attr('value', j);
+                    });
                     $(document).ready(function () {
                         $("#fm1").submit(function () {
                             $(":submit").attr("disabled", true);

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -157,8 +157,8 @@
 
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
-                        var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
-                        var j = /*[[@{#{screen.welcome.button.login}}]]*/
+                        var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please...' ;
+                        var j = /*[[@{#{screen.welcome.button.login}}]]*/ 'Sign in' ;
                     /*]]>*/
                     $(window).on('pageshow', function () {
                         $(':submit').prop('disabled', false);

--- a/src/main/resources/templates/fragments/submitbutton.html
+++ b/src/main/resources/templates/fragments/submitbutton.html
@@ -12,11 +12,22 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div class="form-button" th:fragment="submitButton (buttonCustomization, messageKey)">
+        <div class="form-button" th:fragment="submitButton (buttonDisabled, buttonCustomization, messageKey)">
             <button
                     class="mdc-button mdc-button--raised"
                     th:classappend="${buttonCustomization}"
-                    th:if="${recaptchaSiteKey == null}"
+                    th:if="${recaptchaSiteKey == null && !buttonDisabled}"
+                    name="submit"
+                    accesskey="l"
+                    type="submit">
+                <span class="mdc-button__label" th:text="#{${messageKey}}">Login</span>
+            </button>
+            <button
+                    disabled
+                    id="primarySubmitButton"
+                    class="mdc-button mdc-button--raised"
+                    th:classappend="${buttonCustomization}"
+                    th:if="${recaptchaSiteKey == null && buttonDisabled}"
                     name="submit"
                     accesskey="l"
                     type="submit">

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+    <title></title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body>
+    <main role="main" class="container mt-3 mb-3">
+        <!-- Terms of service consent check login form template begins here -->
+        <div th:fragment="tosloginform" class="d-flex flex-column justify-content-between m-auto">
+
+            <div>
+                <div class="service-ui" th:replace="fragments/osfbannerui :: osfBannerUI">
+                    <a href="fragments/osfbannerui.html"></a>
+                </div>
+            </div>
+
+            <h3 class="text-center text-with-mdi">
+                <i class="mdi mdi-file-document mdi-before-text"></i>
+                <span th:utext="#{screen.tosconsent.instructions.top}"></span>
+            </h3>
+
+            <div class="card-message">
+                <p th:utext="#{screen.tosconsent.message.p1}"></p>
+                <p th:utext="#{screen.tosconsent.message.p2}"></p>
+                <p th:utext="#{screen.tosconsent.message.p3}"></p>
+            </div>
+
+            <div class="form-wrapper">
+                <form method="post" id="fm1" th:object="${credential}" action="login">
+
+                    <section class="cas-field my-2=3">
+                        <span th:if="${availableAuthenticationHandlerNames != null}">
+                            <span th:if="${availableAuthenticationHandlerNames.size() > 1}">
+                                <label for="source" th:utext="#{screen.welcome.label.source}"></label>
+                                <div>
+                                    <select class="form-control required"
+                                            id="source"
+                                            name="source"
+                                            th:field="*{source}">
+                                        <option th:each="handler : ${availableAuthenticationHandlerNames}"
+                                                th:value="${handler}" th:text="${handler}"></option>
+                                    </select>
+                                </div>
+                            </span>
+                            <span th:if="${availableAuthenticationHandlerNames.size() == 1}">
+                                <input type="hidden"
+                                        id="source"
+                                        name="source"
+                                        th:value="${availableAuthenticationHandlerNames.get(0)}"/>
+                            </span>
+                        </span>
+                    </section>
+
+                    <section class="cas-field cas-field-primary">
+                        <div class="instn-consent">
+                            <input type="checkbox" name="termsOfServiceChecked" id="termsOfServiceChecked" value="true" onchange="checkTosConsent(this)" />&nbsp;
+                            <label for="termsOfServiceChecked" th:utext="#{screen.tosconsent.checkbox.title}"></label>
+                        </div>
+                    </section>
+
+                    <section class="cas-field">
+                        <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
+                        <input type="hidden" name="_eventId" value="submit"/>
+                        <input type="hidden" name="geolocation"/>
+                        <p th:if="${#request.getMethod().equalsIgnoreCase('POST')}">
+                            <span th:each="entry : ${httpRequestInitialPostParameters}" th:remove="tag">
+                                <span th:each="entryValue : ${entry.value}" th:remove="tag">
+                                    <input type="hidden" th:name="${entry.key}" th:value="${entryValue}"/>
+                                </span>
+                            </span>
+                        </p>
+                    </section>
+
+                    <div class="form-button">
+                        <button type="submit" name="submit" id="primarySubmitButton" accesskey="l" class="mdc-button mdc-button--raised button-osf-disabled" disabled>
+                            <span class="mdc-button__label" th:text="#{screen.tosconsent.button.agree}"></span>
+                        </button>
+                    </div>
+                </form>
+
+                <script type="text/javascript">
+                    function checkTosConsent(checkbox) {
+                        let submitButton = document.getElementById("primarySubmitButton");
+                        submitButton.disabled = !checkbox.checked;
+                        submitButton.style.backgroundColor = checkbox.checked ? "#357935": "#EFEFEF";
+                    }
+                </script>
+
+                <script type="text/javascript" th:inline="javascript">
+                    /*<![CDATA[*/
+                    var i = /*[[@{#{screen.tosconsent.button.agreewip}}]]*/ 'One moment please...';
+                    var j = /*[[@{#{screen.tosconsent.button.agree}}]]*/ 'Continue';
+                    /*]]>*/
+                    $(window).on('pageshow', function () {
+                        $(':submit').prop('disabled', false);
+                        $(':submit').attr('value', j);
+                    });
+                    $(document).ready(function () {
+                        $("#fm1").submit(function () {
+                            $(":submit").attr("disabled", true);
+                            $(":submit").attr("value", i);
+                            return true;
+                        });
+                    });
+                </script>
+
+            </div>
+        </div>
+    </main>
+</body>
+
+</html>

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -99,7 +99,6 @@
                     var j = /*[[@{#{screen.tosconsent.button.agree}}]]*/ 'Continue';
                     /*]]>*/
                     $(window).on('pageshow', function () {
-                        $(':submit').prop('disabled', false);
                         $(':submit').attr('value', j);
                     });
                     $(document).ready(function () {

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -78,11 +78,8 @@
                         </p>
                     </section>
 
-                    <div class="form-button">
-                        <button type="submit" name="submit" id="primarySubmitButton" accesskey="l" class="mdc-button mdc-button--raised button-osf-disabled" disabled>
-                            <span class="mdc-button__label" th:text="#{screen.tosconsent.button.agree}"></span>
-                        </button>
-                    </div>
+                    <div th:replace="fragments/submitbutton :: submitButton (buttonDisabled=true, buttonCustomization='button-osf-disabled', messageKey='screen.tosconsent.button.agree')" />
+
                 </form>
 
                 <hr class="my-4" />

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -85,6 +85,13 @@
                     </div>
                 </form>
 
+                <hr class="my-4" />
+
+                <div class="text-with-mdi">
+                    <i class="mdi mdi-logout mdi-before-text"></i>
+                    <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.tosconsent.link.cancel}"></a></span>
+                </div>
+
                 <script type="text/javascript">
                     function checkTosConsent(checkbox) {
                         let submitButton = document.getElementById("primarySubmitButton");

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -99,8 +99,8 @@
 
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
-                    var i = /*[[@{#{screen.tosconsent.button.agreewip}}]]*/ 'One moment please...';
-                    var j = /*[[@{#{screen.tosconsent.button.agree}}]]*/ 'Continue';
+                        var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please...';
+                        var j = /*[[@{#{screen.tosconsent.button.agree}}]]*/ 'Continue';
                     /*]]>*/
                     $(window).on('pageshow', function () {
                         $(':submit').attr('value', j);

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -129,8 +129,8 @@
 
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
-                        var i = /*[[@{#{screen.twofactor.button.verifywip}}]]*/
-                        var j = /*[[@{#{screen.twofactor.button.verify}}]]*/
+                        var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please ...' ;
+                        var j = /*[[@{#{screen.twofactor.button.verify}}]]*/ 'Verify' ;
                     /*]]>*/
                     $(window).on('pageshow', function () {
                         $(':submit').prop('disabled', false);

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -73,7 +73,7 @@
                                 th:accesskey="#{screen.welcome.label.email.accesskey}"
                                 th:value="${@casThymeleafLoginFormDirector.getLoginFormUsername(#vars)}"
                                 autocomplete="off" />
-                            <label for="username" class="mdc-floating-label" th:utext="#{screen.welcome.label.email}"></label>
+                            <label for="username" class="mdc-floating-label" th:utext="#{screen.twofactor.label.email}"></label>
                         </div>
                     </section>
 
@@ -111,7 +111,7 @@
                         </p>
                     </section>
 
-                    <div th:replace="fragments/submitbutton :: submitButton (buttonCustomization='button-osf-green', messageKey='screen.twofactor.button.verify')" />
+                    <div th:replace="fragments/submitbutton :: submitButton (buttonDisabled=false, buttonCustomization='button-osf-green', messageKey='screen.twofactor.button.verify')" />
 
                     <div class="form-button">
                         <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=${osfUrl.logout})}">
@@ -129,13 +129,13 @@
 
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
-                    var i = /*[[@{#{screen.twofactor.button.loginwip}}]]*/
-                    var j = /*[[@{#{screen.twofactor.button.login}}]]*/
-                        /*]]>*/
-                        $(window).on('pageshow', function () {
-                            $(':submit').prop('disabled', false);
-                            $(':submit').attr('value', j);
-                        });
+                        var i = /*[[@{#{screen.twofactor.button.verifywip}}]]*/
+                        var j = /*[[@{#{screen.twofactor.button.verify}}]]*/
+                    /*]]>*/
+                    $(window).on('pageshow', function () {
+                        $(':submit').prop('disabled', false);
+                        $(':submit').attr('value', j);
+                    });
                     $(document).ready(function () {
                         $("#fm1").submit(function () {
                             $(":submit").attr("disabled", true);


### PR DESCRIPTION
## Ticket

[ENG-2442](https://openscience.atlassian.net/browse/ENG-2442)

* OSF side supporting PR: https://github.com/CenterForOpenScience/osf.io/pull/9595

## Purpose

Implement terms of service consent check in `newCAS`.

* Institution users no longer need to check the consent checkbox every time. Only users that haven't agreed before will see a dedicated page for them to agree to the terms.
* When OSF updates terms of service, all users will be required to agree to the new terms upon login.

## Changes

* Updated login web flow to support the new user consent feature
* Inform OSF of user's terms of service consent via attribute release
* Removed front-end check on the institution login page
* Updated submit button and related pages

<img width="1031" alt="Screen Shot 2021-01-07 at 5 43 19 PM" src="https://user-images.githubusercontent.com/3750414/103957590-0b447480-5119-11eb-9363-af5e644a0006.png">


## Dev Notes

N / A

## QA Notes

Please refer to the ticket. Given that institution SSO is not available on staging3, you may need to access the admin App to reset the TOS consent for the test users.

## Dev-Ops Notes

* This PR can be merged and deployed independent of https://github.com/CenterForOpenScience/osf.io/pull/9595.
  * With only this PR, you will see the following page upon login since OSF doesn't update the TOS consent info during login.  

<img width="1153" alt="Screen Shot 2021-01-07 at 5 36 33 PM" src="https://user-images.githubusercontent.com/3750414/103957500-d6d0b880-5118-11eb-9da6-ba983711f3c3.png">

  * With this PR and https://github.com/CenterForOpenScience/osf.io/pull/9595, you will see the the following page.

<img width="1153" alt="Screen Shot 2021-01-07 at 5 38 35 PM" src="https://user-images.githubusercontent.com/3750414/103957554-f23bc380-5118-11eb-922d-3f56f629b81d.png">

