### PR TITLE
[No Ticket] Update from 6.2.1 to 6.2.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Versions
-cas.version=6.2.1
+cas.version=6.2.8
 springBootVersion=2.2.8.RELEASE
 
 # Use -jetty, -undertow to other containers


### PR DESCRIPTION
## Purpose

Update CAS overlay template to use the latest `6.2.x`.

* The overlay template has 6.2.6, which is slightly out-dated compared to the primary library. However, local testing hasn't reviewed any issues so far, and thus newCAS uses 6.2.8 now.

* All OAuth 2.0 (server) features are implemented on top of 6.2.8. There are several non-trivial changes in 6.3.x, thus we decided to stick with 6.2.x for the initial full implementation.

* References
  * Apereo CAS library version: https://github.com/apereo/cas/tree/v6.2.8
  * Apereo CAS overlay template version: https://github.com/apereo/cas-overlay-template/commits/6.2
 