### PR TITLE
[ENG-2720] Front-end Polishing (a.k.a Demo / QA Response)

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -597,7 +597,7 @@ screen.unsupp-instn.existing.message=If you have already have an OSF password, y
 screen.unsupp-instn.existing.button=Sign in with OSF
 screen.unsupp-instn.existing.setpw.message=If you have not yet set an OSF password for your account, create a password
 screen.unsupp-instn.existing.setpw.button=Set a password
-screen.unsupp-instn.existing.setpw.label.email=<span class="accesskey">E</span>mail
+screen.unsupp-instn.existing.setpw.label.email=Your OSF Account <span class="accesskey">E</span>mail
 screen.unsupp-instn.existing.setpw.label.email.accesskey=e
 #
 # Generic login and logout success page

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -947,6 +947,7 @@ body {
     height: 56px;
     font-size: 1.125rem;
     margin: 0.5rem 0;
+    padding-left: 1rem;
 }
 
 .login-error-list .banner {

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -814,10 +814,6 @@ body {
     padding-bottom: 1rem;
 }
 
-.osf-shield-with-name-branded {
-    width: 1px;
-}
-
 .osf-shield-with-name .service-ui-logo {
     padding-right: 0.5rem;
 }
@@ -834,7 +830,7 @@ body {
 .osf-shield-with-name .service-ui-name-branded {
     font-size: 2rem;
     font-weight: normal;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
 }
 
 .text-with-mdi,
@@ -1187,10 +1183,6 @@ body {
 
     .form-button-inline .delegation-button-label {
         font-size: 1rem;
-    }
-
-    .osf-shield-with-name .service-ui-name-branded {
-        white-space: normal;
     }
 }
 

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -942,6 +942,10 @@ body {
     padding: 0;
 }
 
+.login-instn-card .form-button {
+    margin: 1rem 0;
+}
+
 .login-section .instn-select select {
     width: 100%;
     height: 56px;

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -887,6 +887,7 @@ body {
     color: black;
     white-space: nowrap;
     padding-left: 28px;
+    letter-spacing: normal;
 }
 
 .form-button .delegation-button-logo {

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi" th:with="loginUrl=@{/login(casRedirectSource=cas)}">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${loginUrl})}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.generic.loginsuccess.link.cancel}"></a></span>
                 </section>
                 <section>

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -37,7 +37,6 @@
                     </section>
 
                     <section class="text-with-mdi text-bold text-large">
-                        <i class="mdi mdi-bank mdi-before-text"></i>
                         <span th:unless=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.select}"></span>
                         <span th:if=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.auto}"></span>
                     </section>
@@ -49,7 +48,6 @@
                     </section>
 
                     <section class="text-with-mdi">
-                        <i class="mdi mdi-checkbox-blank-off-outline mdi-before-text"></i>
                         <span th:if="${osfCasLoginContext.institutionId}">
                             <a th:href="@{/login(campaign=institution, institutionId=${institutionId ?: ''}, service=${service?.originalUrl ?: ''})}" th:utext="#{screen.institutionlogin.link.select}"></a>
                         </span>
@@ -69,14 +67,12 @@
                     <hr class="my-4" />
 
                     <section class="text-with-mdi">
-                        <i class="mdi mdi-account-question-outline mdi-before-text"></i>
                         <span>
                             <a href="https://help.osf.io/hc/en-us/articles/360019737194-Sign-in-to-OSF" th:utext="#{screen.generic.link.support}"></a>
                         </span>
                     </section>
 
                     <section class="text-with-mdi">
-                        <i class="mdi mdi-backburger mdi-before-text"></i>
                         <span>
                             <a th:href="@{/login(service=${service?.originalUrl ?: ''})}" th:utext="#{screen.institutionlogin.osf}"></a>
                         </span>

--- a/src/main/resources/templates/casInstitutionSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoFailedView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi" th:with="loginUrl=@{/login(casRedirectSource=cas)}">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${loginUrl})}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi" th:with="loginUrl=@{/login(casRedirectSource=cas)}">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${loginUrl})}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi" th:with="loginUrl=@{/login(casRedirectSource=cas)}">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=cas)}" th:utext="#{screen.generic.logoutsuccess.link.login}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casOAuth20ErrorView.html
+++ b/src/main/resources/templates/casOAuth20ErrorView.html
@@ -32,7 +32,6 @@
             </section>
             <hr class="my-4" />
             <section class="text-with-mdi">
-                <i class="mdi mdi-login mdi-before-text"></i>
                 <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.oauth.error.exit}"></a></span>
             </section>
         </section>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
                 </section>
             </section>

--- a/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
+++ b/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
@@ -78,7 +78,6 @@
 
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-account-question-outline mdi-before-text"></i>
                     <span>
                             <a href="https://help.osf.io/hc/en-us/articles/360019737194-Sign-in-to-OSF" th:utext="#{screen.generic.link.support}"></a>
                         </span>

--- a/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
+++ b/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
@@ -46,6 +46,10 @@
                     </a>
                 </section>
 
+                <section>
+                    <hr class="hr-text" data-content="OR">
+                </section>
+
                 <section id="osfUnsupportedInstitutionLogin">
                     <div class="card-message">
                         <p th:utext="#{screen.unsupp-instn.existing.setpw.message}"></p>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -34,7 +34,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-logout mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
                 </section>
                 <section>

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -34,7 +34,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=tomcat)}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -34,7 +34,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=tomcat)}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -34,7 +34,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=tomcat)}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -34,7 +34,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=tomcat)}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -34,7 +34,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/login(casRedirectSource=tomcat)}" th:utext="#{screen.error.page.loginagain}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -86,7 +86,8 @@
                                 th:field="*{username}"
                                 th:accesskey="#{screen.welcome.label.email.accesskey}"
                                 th:value="${@casThymeleafLoginFormDirector.getLoginFormUsername(#vars)}"
-                                autocomplete="off" />
+                                autocomplete="off"
+                                autofocus />
                             <label for="username" class="mdc-floating-label" th:utext="#{screen.welcome.label.email}"></label>
                         </div>
                     </section>

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -86,8 +86,7 @@
                                 th:field="*{username}"
                                 th:accesskey="#{screen.welcome.label.email.accesskey}"
                                 th:value="${@casThymeleafLoginFormDirector.getLoginFormUsername(#vars)}"
-                                autocomplete="off"
-                                required />
+                                autocomplete="off" />
                             <label for="username" class="mdc-floating-label" th:utext="#{screen.welcome.label.email}"></label>
                         </div>
                     </section>
@@ -101,8 +100,7 @@
                                     size="25"
                                     th:accesskey="#{screen.welcome.label.password.accesskey}"
                                     th:field="*{password}"
-                                    autocomplete="off"
-                                    required />
+                                    autocomplete="off" />
                                 <label for="username" class="mdc-floating-label" th:utext="#{screen.welcome.label.password}"></label>
                             </div>
                             <div class="mdc-text-field-helper-line caps-warn">

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -88,7 +88,6 @@
                 <hr class="my-4" />
 
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-keyboard-backspace mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.tosconsent.link.cancel}"></a></span>
                 </section>
 

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -80,7 +80,8 @@
                                     maxlength="6"
                                     th:accesskey="#{screen.twofactor.label.onetimepassword.accesskey}"
                                     th:field="*{oneTimePassword}"
-                                    autocomplete="off" />
+                                    autocomplete="off"
+                                    autofocus />
                                 <label for="username" class="mdc-floating-label" th:utext="#{screen.twofactor.label.onetimepassword}"></label>
                             </div>
                         </div>

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -125,7 +125,6 @@
 
                 <section class="cas-field-col-2">
                     <span class="text-with-mdi cas-field-float-left">
-                        <i class="mdi mdi-before-text mdi-keyboard-backspace"></i>
                         <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.twofactor.link.cancel}"></a></span>
                     </span>
                     <span class="text-without-mdi cas-field-float-right">

--- a/src/main/resources/templates/protocol/oauth/confirm.html
+++ b/src/main/resources/templates/protocol/oauth/confirm.html
@@ -37,7 +37,6 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <i class="mdi mdi-login mdi-before-text"></i>
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.oauth.confirm.backtoosf}"></a></span>
                 </section>
             </section>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2720

## Purpose

Polish front-end according to demo and QA feed back (5th round). See https://www.notion.so/cos/newCAS-Release-Plan-2abd2b47c0e84fc99dd6a93072d9733c for details.

## Changes

- ~~Disable submit buttons input for all eligible pages~~ This fix will be moved to its own ticket [ENG-2753](https://openscience.atlassian.net/browse/ENG-2753).
- [x]  Fix the wrapping issue (`width: 1px`) for branded sign-in
- [x]  Increase Indentation on institution select list
- [x]  Reduce letter spacing for ORCiD and Institution login buttons
- [x]  Remove unnecessary leading `mdi` icons in front of links
- [x]  Add a visual divider  `— OR —` between two actions on the institution migration page

### Extras

- [x] Remove default input field style `required`
- [x] Improve email input field hint on the unsupported institution migration page
- [x] Auto focus input fields 

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
