### PR TITLE
[ENG-2763] Fix Invalid Access Type

### DIFF
--- a/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointController.java
+++ b/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointController.java
@@ -245,11 +245,14 @@ public class OAuth20AuthorizeEndpointController extends BaseOAuth20Controller {
                 .map(String::valueOf)
                 .orElseGet(OAuth20GrantTypes.AUTHORIZATION_CODE::getType)
                 .toUpperCase();
-        val accessType = context
+        var accessType = context
                 .getRequestParameter(OsfCasOAuth20Constants.ACCESS_TYPE)
                 .map(String::valueOf)
-                .orElse(OsfCasOAuth20CodeType.ONLINE.name())
+                .orElse(StringUtils.EMPTY)
                 .toUpperCase();
+        if (!OsfCasOAuth20CodeType.OFFLINE.name().equalsIgnoreCase(accessType)) {
+            accessType = OsfCasOAuth20CodeType.ONLINE.name();
+        }
         val scopes = OAuth20Utils.parseRequestScopes(context);
         val codeChallenge = context
                 .getRequestParameter(OAuth20Constants.CODE_CHALLENGE)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2763

## Purpose

Expected behavior: invalid / empty `access_type` is ignored and the default value `ONLINE` is used
Actual behavior: invalid / empty `access_type` crashes the server during authorization approval

## Changes

See reviews in code diff.

## Dev & QA Notes

N / A

## Dev-Ops Notes

N / A
