### PR TITLE
[ENG-2782] Disable Sign-up Button on the TOS consent and 2FA Page

### DIFF
--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/src/main/resources/templates/casInstitutionSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoFailedView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casLoginView.html
+++ b/src/main/resources/templates/casLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casOAuth20ErrorView.html
+++ b/src/main/resources/templates/casOAuth20ErrorView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casTermsOfServiceConsentView.html
+++ b/src/main/resources/templates/casTermsOfServiceConsentView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casTwoFactorLoginView.html
+++ b/src/main/resources/templates/casTwoFactorLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
+++ b/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -39,6 +39,19 @@
         </header>
 
         <script type="text/javascript">
+            function disableSignUpButton() {
+                let signUpButton = document.getElementById("osfRegister");
+                if (signUpButton != null) {
+                    signUpButton.removeAttribute("href");
+                    signUpButton.style.opacity = "0.8";
+                    signUpButton.style.cursor = "not-allowed";
+                    signUpButton.style.backgroundColor = "#efefef";
+                    signUpButton.style.color = "#cccccc";
+                }
+            }
+        </script>
+
+        <script type="text/javascript">
             (function (material) {
                 var header = {
                     init: function () {

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -20,16 +20,16 @@
                         <img class="cas-logo" src="/images/osf-logo-white.png">
                     </span>
                     <div class="cas-brand-text">
-                        <a class="navbar-link" th:href="@{${osfUrl.home}}">
+                        <a class="navbar-link" th:href="@{/login(casRedirectSource=tomcat)}">
                             <span class="cas-brand-name hidden-narrow" >OSF </span>
-                            <span class="cas-brand-name" >HOME</span>
+                            <span class="cas-brand-name" >CAS</span>
                         </a>
                     </div>
                 </section>
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <div class="form-button form-button-navbar">
-                        <a id="osfRegister" class="mdc-button mdc-button--raised button-osf-green" th:href="@{${osfUrl.register}}">
+                        <a class="mdc-button mdc-button--raised button-osf-disabled">
                             <span class="mdc-button__label">Sign up</span>
                         </a>
                     </div>
@@ -37,19 +37,6 @@
 
             </nav>
         </header>
-
-        <script type="text/javascript">
-            function disableSignUpButton() {
-                let signUpButton = document.getElementById("osfRegister");
-                if (signUpButton != null) {
-                    signUpButton.removeAttribute("href");
-                    signUpButton.style.opacity = "0.8";
-                    signUpButton.style.cursor = "not-allowed";
-                    signUpButton.style.backgroundColor = "#efefef";
-                    signUpButton.style.color = "#cccccc";
-                }
-            }
-        </script>
 
         <script type="text/javascript">
             (function (material) {

--- a/src/main/resources/templates/fragments/headerosf.html
+++ b/src/main/resources/templates/fragments/headerosf.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <div th:fragment="headerflowless">
+    <div th:fragment="headerosf">
 
         <header id="app-bar" class="mdc-top-app-bar mdc-top-app-bar--fixed mdc-elevation--z4">
             <nav class="mdc-top-app-bar__row">
@@ -20,16 +20,16 @@
                         <img class="cas-logo" src="/images/osf-logo-white.png">
                     </span>
                     <div class="cas-brand-text">
-                        <a class="navbar-link" th:href="@{/login(casRedirectSource=tomcat)}">
+                        <a class="navbar-link" th:href="@{${osfUrl.home}}">
                             <span class="cas-brand-name hidden-narrow" >OSF </span>
-                            <span class="cas-brand-name" >CAS</span>
+                            <span class="cas-brand-name" >HOME</span>
                         </a>
                     </div>
                 </section>
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <div class="form-button form-button-navbar">
-                        <a class="mdc-button mdc-button--raised button-osf-disabled">
+                        <a id="osfRegister" class="mdc-button mdc-button--raised button-osf-green" th:href="@{${osfUrl.register}}">
                             <span class="mdc-button__label">Sign up</span>
                         </a>
                     </div>
@@ -37,6 +37,19 @@
 
             </nav>
         </header>
+
+        <script type="text/javascript">
+            function disableSignUpButton() {
+                let signUpButton = document.getElementById("osfRegister");
+                if (signUpButton != null) {
+                    signUpButton.removeAttribute("href");
+                    signUpButton.style.opacity = "0.8";
+                    signUpButton.style.cursor = "not-allowed";
+                    signUpButton.style.backgroundColor = "#efefef";
+                    signUpButton.style.color = "#cccccc";
+                }
+            }
+        </script>
 
         <script type="text/javascript">
             (function (material) {

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -99,6 +99,10 @@
                     }
                 </script>
 
+                <script type="text/javascript">
+                    disableSignUpButton();
+                </script>
+
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
                         var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please...';

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -133,6 +133,10 @@
                     </span>
                 </section>
 
+                <script type="text/javascript">
+                    disableSignUpButton();
+                </script>
+
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
                         var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please ...' ;

--- a/src/main/resources/templates/layoutosf.html
+++ b/src/main/resources/templates/layoutosf.html
@@ -21,8 +21,8 @@
 <body>
     <script th:replace="fragments/scripts"></script>
 
-    <div th:replace="fragments/headerflowless :: headerflowless">
-        <a href="fragments/headerflowless.html"></a>
+    <div th:replace="fragments/headerosf :: headerosf">
+        <a href="fragments/headerosf.html"></a>
     </div>
 
     <div class="mdc-drawer-scrim"></div>

--- a/src/main/resources/templates/protocol/oauth/confirm.html
+++ b/src/main/resources/templates/protocol/oauth/confirm.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2782

## Purpose

newCAS’s nav-bar (top-bar) has a green sign-up button on the right side. However, this sign-up button is not always relevant during the login process. The following two pages need to have this page disabled.

* Two-factor login page
* Terms of service consent page

## Changes

* Call `disableSignUpButton()` on both pages. See https://github.com/CenterForOpenScience/osf-cas/pull/32/commits/5b7a1e383023f0079f73b13aed128d223ac6faf6.
* In addition, added missing scripts on the `header.html`. See https://github.com/CenterForOpenScience/osf-cas/pull/32/commits/28b0b74a2b1db41435cdb67741055c86ac54fee9. This is the default flow-unaware one that doesn't affect the two pages in this PR.

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
