### PR TITLE
[ENG-2781] Disable Developer Mode W/ Minor Improvements

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -603,7 +603,7 @@ screen.unsupp-instn.existing.setpw.label.email.accesskey=e
 # Generic login and logout success page
 #
 screen.generic.logoutsuccess.title=Signed-out
-screen.generic.logoutsuccess.tip=Oops! Redirection didn't happen ...
+screen.generic.logoutsuccess.tips=Auto-redirection didn't happen ...
 screen.generic.logoutsuccess.heading=Logout successful
 screen.generic.logoutsuccess.message=You have successfully logged out of OSF. However, you are seeing this page \
   because the automatic redirection somehow didn't happen. Please click the button below to go back to OSF.
@@ -611,7 +611,7 @@ screen.generic.logoutsuccess.button.continue=Back to OSF
 screen.generic.logoutsuccess.link.login=Login again
 #
 screen.generic.loginsuccess.title=Signed-in
-screen.generic.loginsuccess.tips=Oops! Redirection didn't happen ...
+screen.generic.loginsuccess.tips=Auto-redirection didn't happen ...
 screen.generic.loginsuccess.heading=Login successful
 screen.generic.loginsuccess.message=You have successfully logged into OSF! However, you are seeing this page because \
   the automatic redirection somehow didn't happen. Please click the button below to continue to OSF.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -647,6 +647,7 @@ screen.authnerror.tips=Oops! Something went wrong ...
 screen.authnerror.tips.devmode=Developer mode only !!!
 screen.authnerror.button.resendosfconfirmation=Resend confirmation email
 screen.authnerror.button.backtoosf=Exit login
+screen.authnerror.button.logout=Log out
 screen.blocked.message=You are being throttled for attempting to login too frequently in a short amount of time. \
   Please wait for a few minutes before trying again. If you believe this is an error, please contact \
   <a style="white-space: nowrap" href="mailto:support@osf.io">support@osf.io</a> for help.

--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -942,6 +942,13 @@ body {
     padding: 0;
 }
 
+.login-error-card #errorInfo,
+.login-error-card #authnAttr {
+    margin-top: 1rem;
+    padding: 0 1rem;
+    border: solid #e7e7e7;
+}
+
 .login-instn-card .form-button {
     margin: 1rem 0;
 }

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -19,7 +19,7 @@
                         <a href="fragments/osfbannerui.html"></a>
                     </div>
                 </section>
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
+                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title">
                     <span th:utext="#{screen.generic.loginsuccess.tips}"></span>
                 </section>
                 <hr class="my-4" />

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -27,6 +27,13 @@
                     <h2 th:utext="#{screen.generic.loginsuccess.heading}"></h2>
                     <div th:utext="#{screen.generic.loginsuccess.message}"></div>
                 </section>
+                <section class="pre-formatted-small word-break-all">
+                    <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('username'))}" th:utext="${'Email: ' + authentication.principal.attributes.get('username')}"></pre>
+                    <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('givenName')) or #strings.isEmpty(authentication.principal.attributes.get('familyName'))}" th:utext="${'Name: ' + authentication.principal.attributes.get('givenName') + ' ' + authentication.principal.attributes.get('familyName')}"></pre>
+                    <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('osfGuid'))}" th:utext="${'User ID: ' + authentication.principal.attributes.get('osfGuid')}"></pre>
+                    <pre th:unless="${#strings.isEmpty(authentication.principal.id)}" th:utext="${'Principal ID: ' + authentication.principal.id}"></pre>
+                    <pre th:utext="${'Timestamp: ' + #dates.formatISO(#dates.createNow())}"></pre>
+                </section>
                 <section class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{${osfUrl.dashboard}}">
                         <span class="mdc-button__label" th:utext="#{screen.generic.loginsuccess.button.continue}"></span>
@@ -36,8 +43,8 @@
                 <section class="text-with-mdi">
                     <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.generic.loginsuccess.link.cancel}"></a></span>
                 </section>
+                <!--
                 <section>
-                <!-- <section th:if="${osfCasLoginContext.devMode}"> -->
                     <hr class="my-4" />
                     <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                         <span th:utext="#{screen.authnerror.tips.devmode}"></span>
@@ -83,6 +90,7 @@
                         </div>
                     </section>
                 </section>
+                -->
             </section>
         </div>
 

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -27,7 +27,7 @@
                     <h2 th:utext="#{screen.generic.loginsuccess.heading}"></h2>
                     <div th:utext="#{screen.generic.loginsuccess.message}"></div>
                 </section>
-                <section class="pre-formatted-small word-break-all">
+                <section id="authnAttr" class="pre-formatted-small word-break-all">
                     <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('username'))}" th:utext="${'Email: ' + authentication.principal.attributes.get('username')}"></pre>
                     <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('givenName')) or #strings.isEmpty(authentication.principal.attributes.get('familyName'))}" th:utext="${'Name: ' + authentication.principal.attributes.get('givenName') + ' ' + authentication.principal.attributes.get('familyName')}"></pre>
                     <pre th:unless="${#strings.isEmpty(authentication.principal.attributes.get('osfGuid'))}" th:utext="${'User ID: ' + authentication.principal.attributes.get('osfGuid')}"></pre>

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/src/main/resources/templates/casInstitutionSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoFailedView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casLoginView.html
+++ b/src/main/resources/templates/casLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -19,8 +19,8 @@
                         <a href="fragments/osfbannerui.html"></a>
                     </div>
                 </section>
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.generic.loginsuccess.tips}"></span>
+                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title">
+                    <span th:utext="#{screen.generic.logoutsuccess.tips}"></span>
                 </section>
                 <hr class="my-4" />
                 <section class="card-message">

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casOAuth20ErrorView.html
+++ b/src/main/resources/templates/casOAuth20ErrorView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casTermsOfServiceConsentView.html
+++ b/src/main/resources/templates/casTermsOfServiceConsentView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casTwoFactorLoginView.html
+++ b/src/main/resources/templates/casTwoFactorLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
+++ b/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -27,6 +27,12 @@
                     <h2 th:utext="#{screen.unavailable.heading}"></h2>
                     <div th:utext="#{screen.unavailable.message}"></div>
                 </section>
+                <section class="pre-formatted-small word-break-all">
+                    <pre id="initiatorUrl"></pre>
+                    <pre th:utext="${'Error: ' + status + ' - ' + error}"></pre>
+                    <pre th:utext="${'Timestamp: ' + #dates.formatISO(#dates.createNow())}"></pre>
+                    <pre th:text="${'Message: ' + message}"></pre>
+                </section>
                 <section class="form-button" th:with="loginUrl=@{/login(casRedirectSource=cas)}">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=${loginUrl})}">
                         <span class="mdc-button__label" th:utext="#{screen.error.page.loginagain}"></span>
@@ -36,8 +42,8 @@
                 <section class="text-with-mdi">
                     <span><a th:href="@{/logout}" th:utext="#{screen.authnerror.button.logout}"></a></span>
                 </section>
+                <!--
                 <section>
-                <!-- <section th:if="${devMode}"> -->
                     <hr class="my-4" />
                     <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                         <span th:utext="#{screen.authnerror.tips.devmode}"></span>
@@ -64,11 +70,13 @@
                         <pre th:utext="${#strings.escapeXml(trace)}"></pre>
                     </section>
                 </section>
+                -->
             </section>
         </div>
 
         <script type="text/javascript">
             disableSignUpButton();
+            document.getElementById("initiatorUrl").innerHTML = "Request URL: " + window.location.href;
         </script>
 
         <script type="text/javascript">

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -27,7 +27,7 @@
                     <h2 th:utext="#{screen.unavailable.heading}"></h2>
                     <div th:utext="#{screen.unavailable.message}"></div>
                 </section>
-                <section class="pre-formatted-small word-break-all">
+                <section id="errorInfo" class="pre-formatted-small word-break-all">
                     <pre id="initiatorUrl"></pre>
                     <pre th:utext="${'Error: ' + status + ' - ' + error}"></pre>
                     <pre th:utext="${'Timestamp: ' + #dates.formatISO(#dates.createNow())}"></pre>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -34,7 +34,7 @@
                 </section>
                 <hr class="my-4" />
                 <section class="text-with-mdi">
-                    <span><a th:href="@{/logout(service=${osfUrl.logout})}" th:utext="#{screen.authnerror.button.backtoosf}"></a></span>
+                    <span><a th:href="@{/logout}" th:utext="#{screen.authnerror.button.logout}"></a></span>
                 </section>
                 <section>
                 <!-- <section th:if="${devMode}"> -->

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutFlowless}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -39,6 +39,19 @@
         </header>
 
         <script type="text/javascript">
+            function disableSignUpButton() {
+                let signUpButton = document.getElementById("osfRegister");
+                if (signUpButton != null) {
+                    signUpButton.removeAttribute("href");
+                    signUpButton.style.opacity = "0.8";
+                    signUpButton.style.cursor = "not-allowed";
+                    signUpButton.style.backgroundColor = "#efefef";
+                    signUpButton.style.color = "#cccccc";
+                }
+            }
+        </script>
+
+        <script type="text/javascript">
             (function (material) {
                 var header = {
                     init: function () {

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -20,16 +20,16 @@
                         <img class="cas-logo" src="/images/osf-logo-white.png">
                     </span>
                     <div class="cas-brand-text">
-                        <a class="navbar-link" th:href="@{${osfUrl.home}}">
+                        <a class="navbar-link" th:href="@{/login(casRedirectSource=tomcat)}">
                             <span class="cas-brand-name hidden-narrow" >OSF </span>
-                            <span class="cas-brand-name" >HOME</span>
+                            <span class="cas-brand-name" >CAS</span>
                         </a>
                     </div>
                 </section>
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <div class="form-button form-button-navbar">
-                        <a id="osfRegister" class="mdc-button mdc-button--raised button-osf-green" th:href="@{${osfUrl.register}}">
+                        <a class="mdc-button mdc-button--raised button-osf-disabled">
                             <span class="mdc-button__label">Sign up</span>
                         </a>
                     </div>
@@ -37,19 +37,6 @@
 
             </nav>
         </header>
-
-        <script type="text/javascript">
-            function disableSignUpButton() {
-                let signUpButton = document.getElementById("osfRegister");
-                if (signUpButton != null) {
-                    signUpButton.removeAttribute("href");
-                    signUpButton.style.opacity = "0.8";
-                    signUpButton.style.cursor = "not-allowed";
-                    signUpButton.style.backgroundColor = "#efefef";
-                    signUpButton.style.color = "#cccccc";
-                }
-            }
-        </script>
 
         <script type="text/javascript">
             (function (material) {

--- a/src/main/resources/templates/fragments/headerosf.html
+++ b/src/main/resources/templates/fragments/headerosf.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <div th:fragment="headerflowless">
+    <div th:fragment="headerosf">
 
         <header id="app-bar" class="mdc-top-app-bar mdc-top-app-bar--fixed mdc-elevation--z4">
             <nav class="mdc-top-app-bar__row">
@@ -20,16 +20,16 @@
                         <img class="cas-logo" src="/images/osf-logo-white.png">
                     </span>
                     <div class="cas-brand-text">
-                        <a class="navbar-link" th:href="@{/login(casRedirectSource=tomcat)}">
+                        <a class="navbar-link" th:href="@{${osfUrl.home}}">
                             <span class="cas-brand-name hidden-narrow" >OSF </span>
-                            <span class="cas-brand-name" >CAS</span>
+                            <span class="cas-brand-name" >HOME</span>
                         </a>
                     </div>
                 </section>
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <div class="form-button form-button-navbar">
-                        <a class="mdc-button mdc-button--raised button-osf-disabled">
+                        <a id="osfRegister" class="mdc-button mdc-button--raised button-osf-green" th:href="@{${osfUrl.register}}">
                             <span class="mdc-button__label">Sign up</span>
                         </a>
                     </div>
@@ -37,6 +37,19 @@
 
             </nav>
         </header>
+
+        <script type="text/javascript">
+            function disableSignUpButton() {
+                let signUpButton = document.getElementById("osfRegister");
+                if (signUpButton != null) {
+                    signUpButton.removeAttribute("href");
+                    signUpButton.style.opacity = "0.8";
+                    signUpButton.style.cursor = "not-allowed";
+                    signUpButton.style.backgroundColor = "#efefef";
+                    signUpButton.style.color = "#cccccc";
+                }
+            }
+        </script>
 
         <script type="text/javascript">
             (function (material) {

--- a/src/main/resources/templates/fragments/tosloginform.html
+++ b/src/main/resources/templates/fragments/tosloginform.html
@@ -99,6 +99,10 @@
                     }
                 </script>
 
+                <script type="text/javascript">
+                    disableSignUpButton();
+                </script>
+
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
                         var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please...';

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -133,6 +133,10 @@
                     </span>
                 </section>
 
+                <script type="text/javascript">
+                    disableSignUpButton();
+                </script>
+
                 <script type="text/javascript" th:inline="javascript">
                     /*<![CDATA[*/
                         var i = /*[[@{#{screen.generic.button.wip}}]]*/ 'One moment please ...' ;

--- a/src/main/resources/templates/layoutosf.html
+++ b/src/main/resources/templates/layoutosf.html
@@ -21,8 +21,8 @@
 <body>
     <script th:replace="fragments/scripts"></script>
 
-    <div th:replace="fragments/headerflowless :: headerflowless">
-        <a href="fragments/headerflowless.html"></a>
+    <div th:replace="fragments/headerosf :: headerosf">
+        <a href="fragments/headerosf.html"></a>
     </div>
 
     <div class="mdc-drawer-scrim"></div>

--- a/src/main/resources/templates/protocol/oauth/confirm.html
+++ b/src/main/resources/templates/protocol/oauth/confirm.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2781

## Purpose

Disable developer mode on the CAS Unavailable page and the generic login success page

## Changes

### CAS Unavailable Page

<img width="1016" alt="newCAS-errorCasUnavailable" src="https://user-images.githubusercontent.com/3750414/116114908-d0def300-a687-11eb-91b5-fc705b1e0ca5.png">

* Removed the stack trace and the show-hide button.
* Moved error code, message and timestamp to the standard output.
* Added initiator request URL to the standard output
* Restyled error display

### Generic Login Success Page

<img width="1016" alt="newCAS-genericLoginSuccess" src="https://user-images.githubusercontent.com/3750414/116114907-d0def300-a687-11eb-9263-852f98824047.png">

* Removed detailed attributes and show-hide button
* Moved a few attributes (email, names, OSF user GUID and CAS principal ID) to the standard output
* Added UTC timestamp
* Restyled attributes display
* Restyled page tips

### Generic Logout Success Page

<img width="1016" alt="newCAS-genericLogoutSuccess" src="https://user-images.githubusercontent.com/3750414/116114909-d0def300-a687-11eb-8936-0b0b5b5f1b98.png">

* Restyled page tips

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
