### PR TITLE
[ENG-2825] Fix CAS-PAC4J Institution SSO login URL

### DIFF
--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
@@ -110,7 +110,7 @@ public class OsfInstitutionLoginPreparationAction extends OsfAbstractLoginPrepar
                     } else {
                         final String clientUrl = ((DelegatedClientIdentityProviderConfiguration) client).getRedirectUrl();
                         pac4jInstitutionLoginUrlMap.put(clientName, clientUrl);
-                        LOGGER.warn("{}: {}", clientName, clientUrl);
+                        LOGGER.debug("Store PAC4J institution client [{}] with redirect URL [{}] in context", clientName, clientUrl);
                     }
                 }
             }

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -93,11 +93,11 @@
                     }
                     if (institutionLoginUrl === "okstate") {
                         /*<![CDATA[*/
-                            institutionLoginUrl = /*[[${okstateUrl}]]*/ '';
+                            institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('okstate')}]]*/ '';
                         /*]]>*/
                     } else if (institutionLoginUrl === "cord") {
                         /*<![CDATA[*/
-                            institutionLoginUrl = /*[[${cordUrl}]]*/ '';
+                            institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('cord')}]]*/ '';
                         /*]]>*/
                     } else if (institutionLoginUrl === "fakecas") {
                         /*<![CDATA[*/


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2825

## Purpose

Institution SSO doesn't work for `cas-pac4j` institutions on `prod`.
* Go to institution login for Concordia https://accounts.osf.io/login?campaign=institution&institutionId=cord&service=https://osf.io/login/?next%3Dhttps%253A%252F%252Fosf.io%252F
* Click the sign-in button and the login flow ends up on this page https://accounts.osf.io/null with 403

The root cause is that login URLs weren't set for such institutions in the FE template.

## Changes

Set / fixed the URLs

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
