### PR TITLE
[ENG-2826] Supports SAML Validation for PAC4J CAS Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,8 +154,12 @@ dependencies {
     implementation "com.nimbusds:nimbus-jose-jwt:${nimbusJoseVersion}"
     // Apache HttpComponents Client Fluent API
     implementation "org.apache.httpcomponents:fluent-hc:${fluentHcVersion}"
+
     // Jasig CAS Client
+    // The core module supports CAS client for both OAuth login and institution SSO
     implementation "org.jasig.cas.client:cas-client-core:${casClientVersion}"
+    // The SAML module supports SAML validation for CAS-PAC4J institution SSO
+    implementation "org.jasig.cas.client:cas-client-support-saml:${casClientVersion}"
 }
 
 tasks.findByName("jibDockerBuild")


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2826

## Purpose

Concordia login failed due to the class [Saml11TicketValidator](https://github.com/apereo/java-cas-client/blob/cas-client-3.6.1/cas-client-support-saml/src/main/java/org/jasig/cas/client/validation/Saml11TicketValidator.java) not found. Unlike the `fakeCAS` IdP that is used for local testing, `cord` and `okstate` use this SAML validator instead of the built-in CAS validator.

As mentioned in [java-cas-client#components](https://github.com/apereo/java-cas-client#components), newCAS needs an extra dependency in addition to the core module.  

```xml
<dependency>
   <groupId>org.jasig.cas.client</groupId>
   <artifactId>cas-client-support-saml</artifactId>
   <version>${java.cas.client.version}</version>
</dependency>
```

## Changes

Updated `gradle` dependencies with extra comments.

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

N / A
