### PR TITLE
[ENG-2905] Update the institution model and data access object to support deactivated institutions

### DIFF
--- a/src/main/java/io/cos/cas/osf/dao/JpaOsfDao.java
+++ b/src/main/java/io/cos/cas/osf/dao/JpaOsfDao.java
@@ -100,7 +100,7 @@ public class JpaOsfDao extends AbstractOsfDao {
     public OsfInstitution findOneInstitutionById(final String id) {
         try {
             final TypedQuery<OsfInstitution> query = entityManager.createQuery(
-                    "select i from OsfInstitution i where i.institutionId = :id",
+                    "select i from OsfInstitution i where i.institutionId = :id and i.deleted = false and i.dateDeactivated is null",
                     OsfInstitution.class
             );
             query.setParameter("id", id);
@@ -108,7 +108,6 @@ public class JpaOsfDao extends AbstractOsfDao {
         } catch (final PersistenceException e) {
             return null;
         }
-
     }
 
     @Override
@@ -116,7 +115,7 @@ public class JpaOsfDao extends AbstractOsfDao {
         try {
             final TypedQuery<OsfInstitution> query = entityManager.createQuery(
                     "select i from OsfInstitution i "
-                            + "where (not i.delegationProtocol = '') and i.deleted = false",
+                            + "where (not i.delegationProtocol = '') and i.deleted = false and i.dateDeactivated is null",
                     OsfInstitution.class
             );
             return query.getResultList();

--- a/src/main/java/io/cos/cas/osf/model/OsfInstitution.java
+++ b/src/main/java/io/cos/cas/osf/model/OsfInstitution.java
@@ -9,6 +9,9 @@ import lombok.ToString;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
 
 /**
  * This is {@link OsfInstitution}.
@@ -42,6 +45,10 @@ public class OsfInstitution extends AbstractOsfModel {
 
     @Column(name = "is_deleted")
     private Boolean deleted;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "deactivated")
+    private Date dateDeactivated;
 
     public DelegationProtocol getDelegationProtocol() {
         try {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2905

## Purpose

Add a property to the `OsfInstitution` model to read the new `deactivated` field added by [ENG-2904](https://openscience.atlassian.net/browse/ENG-2905) ( [OSF-PR#9703](https://github.com/CenterForOpenScience/osf.io/pull/9703)).

## Changes

* Added a field to the institution model to indicate whether the institution has been deactivated.

* Updated the data access object to filter out deactivated institutions. 

## Dev Notes

N / A

## QA Notes

N / A

## Dev-Ops Notes

- [x] Must be merged / deployed after [OSF-PR#9703](https://github.com/CenterForOpenScience/osf.io/pull/9703).
