### PR TITLE
[ENG-2972][ENG-2973][ENG-3039][ENG-3040][ENG-3042][ENG-3044][ENG-3045][ENG-3047][ENG-3048][ENG-3050][ENG-3052][ENG-3053][ENG-3055][ENG-3056] A11y fixes - 2A and 2AA

### DIFF
--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -37,8 +37,8 @@
                     </section>
 
                     <section class="text-with-mdi text-bold text-large">
-                        <span th:unless=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.select}"></span>
-                        <span th:if=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.auto}"></span>
+                        <label for="institutionSelect" th:unless=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.select}"></label>
+                        <label for="institutionSelect" th:if=${osfCasLoginContext.institutionId} th:utext="#{screen.institutionlogin.heading.auto}"></label>
                     </section>
 
                     <section class="instn-select">

--- a/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
+++ b/src/main/resources/templates/casUnsupportedInstitutionLoginView.html
@@ -65,8 +65,7 @@
                                        size="256"
                                        type="email"
                                        name="forgot_password-email"
-                                       th:accesskey="#{screen.unsupp-instn.existing.setpw.label.email.accesskey}"
-                                       autocomplete="off" />
+                                       th:accesskey="#{screen.unsupp-instn.existing.setpw.label.email.accesskey}" />
                                 <label for="username" class="mdc-floating-label" th:utext="#{screen.unsupp-instn.existing.setpw.label.email}"></label>
                             </div>
                         </section>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -17,7 +17,7 @@
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <span class="cas-brand mx-auto" >
-                        <img class="cas-logo" src="/images/osf-logo-white.png">
+                        <img class="cas-logo" src="/images/osf-logo-white.png" alt="OSF logo image in the top navigation bar">
                     </span>
                     <div class="cas-brand-text">
                         <a class="navbar-link" th:href="@{/login(casRedirectSource=tomcat)}">
@@ -29,7 +29,7 @@
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <div class="form-button form-button-navbar">
-                        <a class="mdc-button mdc-button--raised button-osf-disabled">
+                        <a id="osfRegister" class="mdc-button mdc-button--raised button-osf-disabled">
                             <span class="mdc-button__label">Sign up</span>
                         </a>
                     </div>
@@ -47,8 +47,10 @@
                     signUpButton.style.cursor = "not-allowed";
                     signUpButton.style.backgroundColor = "#efefef";
                     signUpButton.style.color = "#cccccc";
+                    signUpButton.style.visibility = "hidden";
                 }
             }
+            disableSignUpButton();
         </script>
 
         <script type="text/javascript">

--- a/src/main/resources/templates/fragments/headerosf.html
+++ b/src/main/resources/templates/fragments/headerosf.html
@@ -17,7 +17,7 @@
 
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
                     <span class="cas-brand mx-auto" >
-                        <img class="cas-logo" src="/images/osf-logo-white.png">
+                        <img class="cas-logo" src="/images/osf-logo-white.png" alt="OSF logo image in the top navigation bar">
                     </span>
                     <div class="cas-brand-text">
                         <a class="navbar-link" th:href="@{${osfUrl.home}}">
@@ -47,6 +47,7 @@
                     signUpButton.style.cursor = "not-allowed";
                     signUpButton.style.backgroundColor = "#efefef";
                     signUpButton.style.color = "#cccccc";
+                    signUpButton.style.visibility = "hidden";
                 }
             }
         </script>

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -28,11 +28,11 @@
 
             <section class="form-button-inline" th:if="${osfCasLoginContext.orcidLoginUrl}">
                 <a class="mdc-button mdc-button--raised button-osf-grey" id="orcidlogin" th:href="@{${osfCasLoginContext.orcidLoginUrl}}">
-                    <img class="delegation-button-logo" src="/images/orcid-logo.png">
+                    <img class="delegation-button-logo" src="/images/orcid-logo.png" alt="ORCiD logo image for the sign-in-with-orcid button">
                     <span class="delegation-button-label" th:utext="#{screen.welcome.button.orcidlogin}"></span>
                 </a>
                 <a class="mdc-button mdc-button--raised button-osf-grey" id="instnLogin" th:href="@{/login(campaign=institution, institutionId=${institutionId ?: ''}, service=${service?.originalUrl ?: ''})}">
-                    <img class="delegation-button-logo" src="/images/institution-logo.png">
+                    <img class="delegation-button-logo" src="/images/institution-logo.png" alt="Institution logo image for the sign-in-via-orcid button">
                     <span class="delegation-button-label" th:utext="#{screen.welcome.button.institutionlogin}"></span>
                 </a>
             </section>
@@ -101,8 +101,8 @@
                                     size="25"
                                     th:accesskey="#{screen.welcome.label.password.accesskey}"
                                     th:field="*{password}"
-                                    autocomplete="off" />
-                                <label for="username" class="mdc-floating-label" th:utext="#{screen.welcome.label.password}"></label>
+                                    autocomplete="new-password" />
+                                <label for="password" class="mdc-floating-label" th:utext="#{screen.welcome.label.password}"></label>
                             </div>
                             <div class="mdc-text-field-helper-line caps-warn">
                                 <p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg text-danger">

--- a/src/main/resources/templates/fragments/osfbannerui.html
+++ b/src/main/resources/templates/fragments/osfbannerui.html
@@ -13,7 +13,7 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div th:fragment="osfBannerUI" id="osfbannerui" class="mb-4 service-ui text-center">
-            <img id="servicelogo" class="service-ui-logo" src="/images/osf-banner.png" />
+            <img id="servicelogo" class="service-ui-logo" src="/images/osf-banner.png" alt="OSF banner image in the main form"/>
         </div>
     </main>
 </body>

--- a/src/main/resources/templates/fragments/serviceui.html
+++ b/src/main/resources/templates/fragments/serviceui.html
@@ -15,18 +15,18 @@
         <div th:fragment="serviceUI" th:if="${registeredService}" id="serviceui" class="mb-4 service-ui text-center">
             <div th:if="${#strings.equalsIgnoreCase(registeredService.class.simpleName, 'OAuthRegisteredService')}">
                 <div class="osf-banner-without-name">
-                    <img id="serviceLogo" class="service-ui-logo" th:src="@{'images/osf-banner.png'}" />
+                    <img id="serviceLogo" class="service-ui-logo" th:src="@{'images/osf-banner.png'}" alt="OSF banner image in the main form"/>
                 </div>
             </div>
             <div th:unless="${#strings.equalsIgnoreCase(registeredService.class.simpleName, 'OAuthRegisteredService')}">
                 <div class="osf-banner-without-name" th:if="${#strings.isEmpty(registeredService.name)}">
-                    <img id="serviceLogo" class="service-ui-logo" th:src="${registeredService.logo} ? ${registeredService.logo} : @{'images/osf-banner.png'}" />
+                    <img id="serviceLogo" class="service-ui-logo" th:src="${registeredService.logo} ? ${registeredService.logo} : @{'images/osf-banner.png'}" alt="Service banner image in the main form"/>
                 </div>
                 <table class="osf-shield-with-name osf-shield-with-name-branded" th:unless="${#strings.isEmpty(registeredService.name)}">
                     <tbody>
                     <tr>
                         <td>
-                            <img id="serviceLogoBranded" class="service-ui-logo service-ui-logo-branded" th:src="${registeredService.logo} ? ${registeredService.logo} : @{'images/osf-logo.png'}" />
+                            <img id="serviceLogoBranded" class="service-ui-logo service-ui-logo-branded" th:src="${registeredService.logo} ? ${registeredService.logo} : @{'images/osf-logo.png'}" alt="Service logo image in the main form"/>
                         </td>
                         <td>
                             <span id="serviceNameBranded" class="service-ui-name service-ui-name-branded" th:text="${registeredService.name}"></span>

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -80,9 +80,9 @@
                                     maxlength="6"
                                     th:accesskey="#{screen.twofactor.label.onetimepassword.accesskey}"
                                     th:field="*{oneTimePassword}"
-                                    autocomplete="off"
+                                    autocomplete="new-password"
                                     autofocus />
-                                <label for="username" class="mdc-floating-label" th:utext="#{screen.twofactor.label.onetimepassword}"></label>
+                                <label for="oneTimePassword" class="mdc-floating-label" th:utext="#{screen.twofactor.label.onetimepassword}"></label>
                             </div>
                         </div>
                         <button class="reveal-password mdc-button mdc-button--raised mdc-input-group-append" type="button">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" lang="en-us">
 
 <head>
     <meta charset="UTF-8" />

--- a/src/main/resources/templates/layoutosf.html
+++ b/src/main/resources/templates/layoutosf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" lang="en-us">
 
 <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Ticket

See **Changes**

## Purpose

A11y fixes - 2A and 2AA

## Changes

* Pages covered
  * Login page
    * https://openscience.atlassian.net/browse/ENG-2972
    * https://openscience.atlassian.net/browse/ENG-2973
  * Two-factor
    * https://openscience.atlassian.net/browse/ENG-3039
    * https://openscience.atlassian.net/browse/ENG-3040
    * https://openscience.atlassian.net/browse/ENG-3042
  * Terms-of-service
    * https://openscience.atlassian.net/browse/ENG-3044
    * https://openscience.atlassian.net/browse/ENG-3045
  * Institution and SSO pages
    * https://openscience.atlassian.net/browse/ENG-3050
    * https://openscience.atlassian.net/browse/ENG-3052
    * https://openscience.atlassian.net/browse/ENG-3053
  * OAuth Pages
    * https://openscience.atlassian.net/browse/ENG-3047
    * https://openscience.atlassian.net/browse/ENG-3048
  * Exception Pages
    * https://openscience.atlassian.net/browse/ENG-3055
    * https://openscience.atlassian.net/browse/ENG-3056 

* Issues fixed
  * Added the `alt` attribute for `<img>` tags
  * Fixed the `label` tag for password and one-time password inputs
  * Set `auto-complete` to `new-password` for password and one-time password inputs
  * Replace `<span>` tags with `<label>` for `select` forms in institution pages
    * Instead of adding an invisible label, I re-tag the `<span>` above the `<select>` to `<label>`
    * Selenium tests may have missed one page: institution SSO page with an auto-selected institution. This page should suffer the same issue which is fixed as a side-effect.
  * Remove auto-complete for email inputs
    * The "username/email" input in the login forms are `text` input while the one in the unsupported institution SSO page is `email`. Instead of changing it to `text` to support `auto-complete`, I simply removed the `auto-complete`.
  * Added lang="en-us" to the html tag
  * Hide "disabled" sign-up button-like div
    * Unlike `<button>`, bottuon-like `<div>` does not have the `disabled` attribute. Hopefully, hiding it would word.

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A
