### PR TITLE
[ENG-3479] Another logger upgrade for CAS 6.2.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,4 +33,4 @@ gsonVersion=2.8.6
 hibernateCoreVersion=5.4.21.Final
 nimbusJoseVersion=8.20.1
 springBootTomcatVersion=9.0.37
-log4jVersion=2.15.0
+log4jVersion=2.16.0


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-3479

## Purpose

Bump log4j from 2.15.0 to 2.16.0 according to [log4j](https://logging.apache.org/log4j/2.x/security.html).

> It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data using a JNDI Lookup pattern, resulting in an information leak and remote code execution in some environments and local code execution in all environments; remote code execution has been demonstrated on macOS but no other tested environments.

In addition, [here](https://github.com/apereo/cas/commit/a75a5f4b20dc624d11ad3f3639cf9d7293f14c96) is the the official Apereo fix applied to 6.3.x and 6.4.x

## Changes

See **Purpose**

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A
