### PR TITLE
[ENG-3501] Automatically bump copyright year

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -516,7 +516,7 @@ cas.login.resources.osf.donate=Donate
 #
 # Footer
 #
-copyright.cos=<span style="white-space: nowrap">Copyright &copy; 2011 &ndash; 2021</span>&#160;\
+copyright.cos=<span style="white-space: nowrap">Copyright &copy; 2011 &ndash; {0}</span>&#160;\
   <a style="white-space: nowrap" href="https://cos.io">Center for Open Science</a> &#124;&#160;\
   <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a>&#160;&#124;&#160;\
   <a style="white-space: nowrap" href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>&#160;&#124;&#160;\

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,3 +1,7 @@
 <footer class="py-4 d-flex justify-content-center cas-footer cas-footer-osf">
-    <span id="copyright" th:utext="#{copyright.cos}" class="mr-2 d-inline-block copyright"></span>
+    <span id="copyright-2"
+          th:with="year=${#dates.year(#dates.createNow())}"
+          th:utext="#{copyright.cos(${year.toString()})}"
+          class="mr-2 d-inline-block copyright">
+    </span>
 </footer>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-3501

## Purpose

We are in 2022! Bump copyright year ... and make the update automatic from now on.

## Changes

See **Purpose**

## Dev Notes

Spring somehow decides to format number by adding commas, which must be a format setting somewhere.

<img width="734" alt="Screen Shot 2022-01-10 at 11 22 50 AM" src="https://user-images.githubusercontent.com/3750414/148801016-137afbc6-75c0-4720-800f-7c9b2ec39c87.png">

Must add `.toString()` in the template to mitigate that.

<img width="732" alt="Screen Shot 2022-01-10 at 11 25 45 AM" src="https://user-images.githubusercontent.com/3750414/148801308-b41fa2c2-db05-4842-8992-bfa2726cb511.png">

## QA Notes

N/A

## Dev-Ops Notes

- [ ] Merge and deploy only after server configurations (unrelated) are updated in https://github.com/CenterForOpenScience/osf.io/pull/9859 to avoid unnecessary back-to-back deployments.
