### PR TITLE
[ENG-3544] Fix autocomplete for password and one-time code input fields

### DIFF
--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -101,7 +101,7 @@
                                     size="25"
                                     th:accesskey="#{screen.welcome.label.password.accesskey}"
                                     th:field="*{password}"
-                                    autocomplete="new-password" />
+                                    autocomplete="current-password" />
                                 <label for="password" class="mdc-floating-label" th:utext="#{screen.welcome.label.password}"></label>
                             </div>
                             <div class="mdc-text-field-helper-line caps-warn">

--- a/src/main/resources/templates/fragments/totploginform.html
+++ b/src/main/resources/templates/fragments/totploginform.html
@@ -80,7 +80,7 @@
                                     maxlength="6"
                                     th:accesskey="#{screen.twofactor.label.onetimepassword.accesskey}"
                                     th:field="*{oneTimePassword}"
-                                    autocomplete="new-password"
+                                    autocomplete="one-time-code"
                                     autofocus />
                                 <label for="oneTimePassword" class="mdc-floating-label" th:utext="#{screen.twofactor.label.onetimepassword}"></label>
                             </div>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-3544

## Purpose

Fix `autocomplete` for the password and one-time code input fields

## Changes

Please refer to the [ticket](https://openscience.atlassian.net/browse/ENG-3544)

## Dev Notes

N/A

## QA Notes

* In addition to Firefox, Safari isn't affected by this bug either.

## Dev-Ops Notes

N/A
