### PR TITLE
[ENG-3507] Institution Selective SSO - CAS Part

### DIFF
--- a/etc/cas/config/local/instn-authn-local.xsl
+++ b/etc/cas/config/local/instn-authn-local.xsl
@@ -15,104 +15,68 @@
                     <xsl:value-of select="$idp"/>
                 </idp>
                 <xsl:choose>
-                    <!--  Example SAML-auth University -->
-                    <xsl:when test="$idp='example-shib-auth-univeristy-entity-id'">
-                        <id>esu</id>
+                    <!-- An example SAML-auth institution without any special features -->
+                    <xsl:when test="$idp='fake-saml-idp-type-0-default'">
+                        <id>fake-saml-type-0</id>
                         <user>
-                            <!--  Each institution has its customized mapping of attributes  -->
-                            <username>
-                                <xsl:value-of select="//attribute[@name='eppn']/@value"/>
-                            </username>
-                            <isMemberOf>
-                                <xsl:value-of select="//attribute[@name='ismemberof']/@value"/>
-                            </isMemberOf>
-                            <departmentRaw>
-                                <xsl:value-of select="//attribute[@name='department']/@value"/>
-                            </departmentRaw>
-                            <eduPerson>false</eduPerson>
-                            <fullname>
-                                <xsl:value-of select="//attribute[@name='displayname']/@value"/>
-                            </fullname>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='sn']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenname']/@value"/>
-                            </givenName>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
                             <middleNames/>
                             <suffix/>
                         </user>
                     </xsl:when>
-                    <!-- Brown University (BROWN) -->
-                    <xsl:when test="$idp='https://sso.brown.edu/idp/shibboleth'">
-                        <id>brown</id>
+                    <!-- An example SAML institution that has Shared SSO enabled -->
+                    <xsl:when test="$idp='fake-saml-idp-type-1-shared-sso'">
+                        <id>fake-saml-type-1</id>
                         <user>
-                            <username>
-                                <xsl:value-of select="//attribute[@name='mail']/@value"/>
-                            </username>
-                            <isMemberOf>
-                                <xsl:value-of select="//attribute[@name='ismemberof']/@value"/>
-                            </isMemberOf>
-                            <fullname>
-                                <xsl:value-of select="//attribute[@name='displayname']/@value"/>
-                            </fullname>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='sn']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenname']/@value"/>
-                            </givenName>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <isMemberOf><xsl:value-of select="//attribute[@name='ismemberof']/@value"/></isMemberOf>
+                            <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
                             <middleNames/>
                             <suffix/>
                         </user>
                     </xsl:when>
-                    <!-- Princeton University (PU) -->
-                    <!--
-                        The departmentRaw and eduPerson attributes are for local testing purpose only.
-                        Princeton does not release such an attribute yet.
-                    -->
-                    <xsl:when test="$idp='https://idp.princeton.edu/idp/shibboleth'">
-                        <id>pu</id>
+                    <!-- An example SAML-auth institution that has selective SSO enabled -->
+                    <xsl:when test="$idp='fake-saml-idp-type-2-selective-sso'">
+                        <id>fake-saml-type-2</id>
                         <user>
-                            <username>
-                                <xsl:value-of select="//attribute[@name='mail']/@value"/>
-                            </username>
-                            <departmentRaw>
-                                <xsl:value-of select="//attribute[@name='department']/@value"/>
-                            </departmentRaw>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <isSelectiveSso>true</isSelectiveSso>
+                            <selectiveSsoFilter><xsl:value-of select="//attribute[@name='selectivessofilter']/@value"/></selectiveSsoFilter>
+                            <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
+                    <!-- An example SAML-auth institution that uses `eduPersonPrimaryOrgUnitDN` for the department attribute -->
+                    <xsl:when test="$idp='fake-saml-idp-type-3-department-eduperson'">
+                        <id>fake-saml-type-3</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
                             <eduPerson>true</eduPerson>
-                            <fullname>
-                                <xsl:value-of select="//attribute[@name='displayname']/@value"/>
-                            </fullname>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='sn']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenname']/@value"/>
-                            </givenName>
+                            <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
                             <suffix/>
                         </user>
                     </xsl:when>
-                    <!-- University of Arizona (UA) -->
-                    <xsl:when test="$idp='urn:mace:incommon:arizona.edu'">
-                        <id>ua</id>
+                    <!-- An example SAML-auth institution that uses a customized department attribute -->
+                    <xsl:when test="$idp='fake-saml-idp-type-4-department-customized'">
+                        <id>fake-saml-type-4</id>
                         <user>
-                            <username>
-                                <xsl:value-of select="//attribute[@name='mail']/@value"/>
-                            </username>
-                            <departmentRaw>
-                                <xsl:value-of select="//attribute[@name='department']/@value"/>
-                            </departmentRaw>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
                             <eduPerson>false</eduPerson>
-                            <fullname>
-                                <xsl:value-of select="//attribute[@name='displayname']/@value"/>
-                            </fullname>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='sn']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenname']/@value"/>
-                            </givenName>
+                            <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
                             <middleNames/>
                             <suffix/>
                         </user>
@@ -131,51 +95,13 @@
                     <xsl:value-of select="$idp"/>
                 </idp>
                 <xsl:choose>
-                    <!--  Example CAS-auth University  -->
-                    <xsl:when test="$idp='ecu'">
-                        <id>ecu</id>
+                    <!--  An example CAS-auth institution without any special features  -->
+                    <xsl:when test="$idp='fake-cas-idp-type-0-default'">
+                        <id>fake-cas-type-0</id>
                         <user>
-                            <!--  Each institution has its customized mapping of attributes  -->
-                            <username>
-                                <xsl:value-of select="//attribute[@name='mail']/@value"/>
-                            </username>
-                            <isMemberOf>
-                                <xsl:value-of select="//attribute[@name='ismemberof']/@value"/>
-                            </isMemberOf>
-                            <departmentRaw>
-                                <xsl:value-of select="//attribute[@name='department']/@value"/>
-                            </departmentRaw>
-                            <eduPerson>false</eduPerson>
-                            <fullname>
-                                <xsl:value-of select="//attribute[@name='displayname']/@value"/>
-                            </fullname>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='sn']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenname']/@value"/>
-                            </givenName>
-                            <middleNames/>
-                            <suffix/>
-                        </user>
-                    </xsl:when><!--  Example CAS-auth University  -->
-                    <xsl:when test="$idp='fakecas'">
-                        <id>fakecas</id>
-                        <user>
-                            <!-- Tweaked fakeCAS as an institution IdP for local development -->
-                            <username>
-                                <xsl:value-of select="//attribute[@name='username']/@value"/>
-                            </username>
-                            <departmentRaw>
-                                <xsl:value-of select="//attribute[@name='department']/@value"/>
-                            </departmentRaw>
-                            <eduPerson>false</eduPerson>
-                            <familyName>
-                                <xsl:value-of select="//attribute[@name='familyName']/@value"/>
-                            </familyName>
-                            <givenName>
-                                <xsl:value-of select="//attribute[@name='givenName']/@value"/>
-                            </givenName>
+                            <username><xsl:value-of select="//attribute[@name='username']/@value"/></username>
+                            <familyName><xsl:value-of select="//attribute[@name='familyName']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
                             <fullname/>
                             <middleNames/>
                             <suffix/>

--- a/src/main/java/io/cos/cas/osf/authentication/exception/InstitutionSelectiveSsoFailedException.java
+++ b/src/main/java/io/cos/cas/osf/authentication/exception/InstitutionSelectiveSsoFailedException.java
@@ -1,0 +1,29 @@
+package io.cos.cas.osf.authentication.exception;
+
+import lombok.NoArgsConstructor;
+
+import javax.security.auth.login.AccountException;
+
+/**
+ * Describes an authentication error condition where user is not allowed to access OSF via institution SSO.
+ *
+ * @author Longze Chen
+ * @since 22.0.0
+ */
+@NoArgsConstructor
+public class InstitutionSelectiveSsoFailedException extends AccountException {
+
+    /**
+     * Serialization metadata.
+     */
+    private static final long serialVersionUID = -7613915260905373074L;
+
+    /**
+     * Instantiates a new {@link InstitutionSelectiveSsoFailedException}.
+     *
+     * @param msg the msg
+     */
+    public InstitutionSelectiveSsoFailedException(final String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfApiPermissionDenied.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfApiPermissionDenied.java
@@ -1,0 +1,37 @@
+package io.cos.cas.osf.authentication.support;
+
+/**
+ * This is {@link OsfApiPermissionDenied}.
+ *
+ * @author Longze Chen
+ * @since 22.0.0
+ */
+public enum OsfApiPermissionDenied {
+
+    DEFAULT("PermissionDenied"),
+
+    INSTITUTION_SELECTIVE_SSO_FAILURE("InstitutionSsoSelectiveNotAllowed");
+
+    private final String id;
+
+    OsfApiPermissionDenied(final String id) {
+        this.id = id;
+    }
+
+    public static OsfApiPermissionDenied getType(final String id) throws IllegalArgumentException {
+        if (id == null) {
+            return null;
+        }
+
+        for (final OsfApiPermissionDenied type : OsfApiPermissionDenied.values()) {
+            if (id.equals(type.getId())) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No matching type for id " + id);
+    }
+
+    public final String getId() {
+        return id;
+    }
+}

--- a/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
@@ -2,6 +2,7 @@ package io.cos.cas.osf.web.flow.config;
 
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedIdpException;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedOsfException;
+import io.cos.cas.osf.authentication.exception.InstitutionSelectiveSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InvalidOneTimePasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidPasswordException;
@@ -48,6 +49,7 @@ public class OsfCasCoreWebflowConfiguration extends CasCoreWebflowConfiguration 
         errors.add(InvalidUserStatusException.class);
         errors.add(InvalidVerificationKeyException.class);
         errors.add(OneTimePasswordRequiredException.class);
+        errors.add(InstitutionSelectiveSsoFailedException.class);
         errors.add(TermsOfServiceConsentRequiredException.class);
 
         // Add built-in exceptions after OSF-specific exceptions since order matters

--- a/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
@@ -3,6 +3,7 @@ package io.cos.cas.osf.web.flow.configurer;
 import io.cos.cas.osf.authentication.credential.OsfPostgresCredential;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedIdpException;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedOsfException;
+import io.cos.cas.osf.authentication.exception.InstitutionSelectiveSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InvalidOneTimePasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidUserStatusException;
@@ -259,6 +260,11 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
                 InstitutionSsoFailedException.class.getSimpleName(),
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SSO_FAILED
         );
+        createTransitionForState(
+                handler,
+                InstitutionSelectiveSsoFailedException.class.getSimpleName(),
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED
+        );
 
         // The default transition
         createStateDefaultTransition(handler, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM);
@@ -403,6 +409,11 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
                 flow,
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SSO_FAILED,
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SSO_FAILED
+        );
+        createViewState(
+                flow,
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED,
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED
         );
     }
 

--- a/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
@@ -62,5 +62,7 @@ public interface OsfCasWebflowConstants {
 
     String VIEW_ID_INSTITUTION_SSO_FAILED = "casInstitutionSsoFailedView";
 
+    String VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED = "casInstitutionSelectiveSsoFailedView";
+
     String VIEW_ID_OAUTH_20_ERROR_VIEW = "casOAuth20ErrorView";
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -690,6 +690,9 @@ screen.institutionssofailed.message=Your request cannot be completed at this tim
   <a style="white-space: nowrap" href="{0}">return to OSF</a> and try again later.</br></br>If the issue persists, \
   check with your institution to verify your account is entitled to authenticate to OSF.</br></br>If you believe this \
   is in error, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
+screen.institutionselectivessofailed.message=Your institutional account is unable to authenticate to OSF. \
+  Please check with your institution. If your institution believes this is in error, please contact \
+  <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
 #
 # OAuth 2.0 Views and Error Views
 #

--- a/src/main/resources/templates/casInstitutionSelectiveSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSelectiveSsoFailedView.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+    <title th:text="#{screen.institutionssofailed.title}"></title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body class="mdc-typography">
+    <div layout:fragment="content" class="d-flex justify-content-center">
+
+        <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
+            <section class="login-error-card">
+                <section>
+                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
+                        <a href="fragments/osfbannerui.html"></a>
+                    </div>
+                </section>
+                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
+                    <span th:utext="#{screen.authnerror.tips}"></span>
+                </section>
+                <hr class="my-4" />
+                <section class="card-message">
+                    <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
+                    <p th:utext="#{screen.institutionselectivessofailed.message}"></p>
+                </section>
+                <section class="form-button">
+                    <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=${osfUrl.logout})}">
+                        <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
+                    </a>
+                </section>
+                <hr class="my-4" />
+                <section class="text-with-mdi" th:with="loginUrl=@{${@casServerLoginUrl}(casRedirectSource=cas)}">
+                    <span><a th:href="@{/logout(service=${loginUrl})}" th:utext="#{screen.error.page.loginagain}"></a></span>
+                </section>
+            </section>
+        </div>
+
+        <script type="text/javascript">
+            disableSignUpButton();
+        </script>
+
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Ticket

### CAS Part (This PR)

[ENG-3507](https://openscience.atlassian.net/browse/ENG-3507)

### OSF API Part

[ENG-3508](https://github.com/CenterForOpenScience/osf.io/pull/9877/files) with [PR-OSF#9877](https://github.com/CenterForOpenScience/osf.io/pull/9877)

## Purpose

Implement selective SSO for institution login.

## Changes

### Selective SSO

* Updated class `OsfPrincipalFromNonInteractiveCredentialsAction` to support institution selective SSO.
* Reworked API response handling to identify selective SSO failures
* Updated the web flow with new exception and error page

### Coding

* Flattened the convoluted control flow for handling institution SSO failures
* Make `try {} catch {}` blocks finder-grained 

### Local Testing

* Reworked local Postman tests
* Updated `instn-authn-local.xsl` to support new tests.

## Dev Notes

N/A

## QA Notes

This can only be tested by institution parters. Here is the new error page.

<img width="536" alt="Instituiton Selective SSO Denied Exception Page" src="https://user-images.githubusercontent.com/3750414/153670761-4b269ba8-a1cc-4625-8663-48b06f11d6d2.png">


## Dev-Ops Notes

Although this PR has a backend piece: https://github.com/CenterForOpenScience/osf.io/pull/9877 it (both) can be merged / deployed independently of each other.
