### PR TITLE
[ENG-3623] Support via-ORCiD Institutions

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/support/DelegationProtocol.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/DelegationProtocol.java
@@ -14,7 +14,9 @@ public enum DelegationProtocol {
 
     CAS_PAC4J("cas-pac4j"),
 
-    SAML_SHIB("saml-shib");
+    SAML_SHIB("saml-shib"),
+
+    AFFILIATION_VIA_ORCID("via-orcid");
 
     private final String id;
 

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -22,6 +22,8 @@ import java.util.Map;
 @Slf4j
 public final class OsfInstitutionUtils {
 
+    public final static String ORCID_SUFFIX = " (via ORCiD SSO)";
+
     public static boolean validateInstitutionForLogin(final JpaOsfDao jpaOsfDao, final String id) {
         final OsfInstitution institution = jpaOsfDao.findOneInstitutionById(id);
         return institution != null && institution.getDelegationProtocol() != null;
@@ -53,6 +55,8 @@ public final class OsfInstitutionUtils {
                 );
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(institution.getInstitutionId(), institution.getName());
+            } else if (DelegationProtocol.AFFILIATION_VIA_ORCID.equals(delegationProtocol)) {
+                institutionLoginUrlMap.put(DelegationProtocol.AFFILIATION_VIA_ORCID.getId(), institution.getName() + ORCID_SUFFIX);
             }
         }
         return institutionLoginUrlMap;

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -99,10 +99,12 @@
                         /*<![CDATA[*/
                             institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('cord')}]]*/ '';
                         /*]]>*/
-                    } else if (institutionLoginUrl === "fakecas") {
+                    } else if (institutionLoginUrl === "fake-cas-type-5") {
                         /*<![CDATA[*/
-                            institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('fakecas')}]]*/ '';
+                        institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('fake-cas-type-5')}]]*/ '';
                         /*]]>*/
+                    } else if (institutionLoginUrl === "via-orcid") {
+                        institutionLoginUrl = /*[[${osfCasLoginContext.orcidLoginUrl}]]*/ ''
                     } else {
                         let lastIndexOfHash = institutionLoginUrl.lastIndexOf("#");
                         if (lastIndexOfHash >= 0) {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-3623

## Purpose

Update CAS to support institutions of which SSO and affiliation is done via ORCiD.

## Changes

We've chosen the balanced solution out the three in the ticket.

* CAS list `via-orcid` institutions in the drop-down list with extra note "via ORCiD SSO" appended as suffix.
* When clicked, it redirects user to ORCiD login and the rest follow standard ORCiD login flow
* Affiliation is done in OSF and thus out of the scope of this PR

https://user-images.githubusercontent.com/3750414/155822339-eab7a559-4b61-4f33-8831-96aa7122d13a.mov

## Dev Notes

N/A

## QA Notes

- QA notes will be updated when the full feature is ready for test

## Dev-Ops Notes

- ~~This PR can be merged without its OSF part: https://github.com/CenterForOpenScience/osf.io/pull/9888. The new feature simply won't take effect until OSF is updated.~~ No longer relevant since this PR goes to a feature branch instead of develop directly.
