### PR TITLE
[ENG-3773] Enable CAS health endpoint for K8s probing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,8 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-token-core-api:${project.'cas.version'}"
     // Throttling
     implementation "org.apereo.cas:cas-server-support-throttle:${project.'cas.version'}"
+    // Monitoring & Statistics
+    implementation "org.apereo.cas:cas-server-support-reports:${project.'cas.version'}"
 
     // Tomcat Catalina
     implementation "org.apache.tomcat:tomcat-catalina:${springBootTomcatVersion}"

--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -37,9 +37,9 @@ cas.authn.throttle.failure.range-seconds=1
 # See: https://docs.spring.io/spring-boot/docs/2.2.8.RELEASE/reference/htmlsingle/#boot-features-security
 # Currently, no sensitive endpoint is exposed. However, set them to prevent auto-generated and logged password
 ########################################################################################################################
-spring.security.user.name=${SPRING_SECURITY_USER_NAME:casuser}
-spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD:}
-spring.security.user.roles=${SPRING_SECURITY_USER_ROLES:}
+# spring.security.user.name=${SPRING_SECURITY_USER_NAME:casuser}
+# spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD:}
+# spring.security.user.roles=${SPRING_SECURITY_USER_ROLES:}
 ########################################################################################################################
 
 ########################################################################################################################
@@ -210,10 +210,12 @@ cas.tgc.pin-to-session=true
 cas.tgc.remember-me-max-age=P28D
 cas.tgc.auto-configure-cookie-path=true
 #
-# Ticket Granting Ticket Persistence Settings
+# Ticket Granting Ticket Settings
 #
+cas.ticket.tgt.max-time-to-live-in-seconds=7776000
+cas.ticket.tgt.time-to-kill-in-seconds=7776000
 cas.ticket.tgt.remember-me.enabled=true
-cas.ticket.tgt.remember-me.time-to-kill-in-seconds=7200
+cas.ticket.tgt.remember-me.time-to-kill-in-seconds=7776000
 ########################################################################################################################
 
 ########################################################################################################################
@@ -244,12 +246,12 @@ cas.authn.pac4j.orcid.callback-url-type=QUERY_PARAMETER
 #
 # Delegation Client: CAS
 #
-cas.authn.pac4j.cas[0].login-url=https://bprdeis.cord.edu:8443/cas/login
+cas.authn.pac4j.cas[0].login-url=${CAS_CORD_LOGIN_URL:https://bprdeis.cord.edu:8443/cas/login}
 cas.authn.pac4j.cas[0].client-name=cord
 cas.authn.pac4j.cas[0].protocol=SAML
 cas.authn.pac4j.cas[0].callback-url-type=QUERY_PARAMETER
 #
-cas.authn.pac4j.cas[1].login-url=https://stwcas.okstate.edu/cas/login
+cas.authn.pac4j.cas[1].login-url=${CAS_OKSTATE_LOGIN_URL:https://stwcas.okstate.edu/cas/login}
 cas.authn.pac4j.cas[1].client-name=okstate
 cas.authn.pac4j.cas[1].protocol=SAML
 cas.authn.pac4j.cas[1].callback-url-type=QUERY_PARAMETER
@@ -266,9 +268,9 @@ cas.authn.oauth.code.time-to-kill-in-seconds=60
 cas.authn.oauth.code.number-of-uses=1
 #
 # Access token
-#
-cas.authn.oauth.access-token.time-to-kill-in-seconds=7200
-cas.authn.oauth.access-token.max-time-to-live-in-seconds=28800
+# Both time-to-kill and max-time-to-live must be set the same since the OAuth 2.0 protocol only defines one
+cas.authn.oauth.access-token.time-to-kill-in-seconds=3600
+cas.authn.oauth.access-token.max-time-to-live-in-seconds=3600
 #
 # OAuth JWT Access Tokens
 # Signing and encryption are not enabled for Token / JWT Tickets.
@@ -282,11 +284,11 @@ cas.authn.oauth.access-token.crypto.encryption.key=${OAUTH_JWT_ACCESS_TOKEN_ENCR
 #
 # Refresh token
 #
-cas.authn.oauth.refresh-token.time-to-kill-in-seconds=2592000
+cas.authn.oauth.refresh-token.time-to-kill-in-seconds=7776000
 #
 # Personal access token
 #
-cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=2592000
+cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=31104000
 cas.authn.oauth.personal-access-token.max-time-to-live-in-seconds=31104000
 #
 # Signing and encryption for OAuth registered service

--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -33,6 +33,16 @@ cas.authn.throttle.failure.range-seconds=1
 ########################################################################################################################
 
 ########################################################################################################################
+# CAS Monitoring & Statistics Endpoints
+# See: https://apereo.github.io/cas/6.2.x/monitoring/Monitoring-Statistics.html
+########################################################################################################################
+management.endpoints.web.exposure.include=health
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=WHEN_AUTHORIZED
+cas.monitor.endpoints.endpoint.health.access=ANONYMOUS
+########################################################################################################################
+
+########################################################################################################################
 # CAS Web Application Endpoints Security
 # See: https://docs.spring.io/spring-boot/docs/2.2.8.RELEASE/reference/htmlsingle/#boot-features-security
 # Currently, no sensitive endpoint is exposed. However, set them to prevent auto-generated and logged password

--- a/etc/cas/config/local/cas-local.properties
+++ b/etc/cas/config/local/cas-local.properties
@@ -39,6 +39,16 @@ cas.authn.throttle.failure.range-seconds=1
 ########################################################################################################################
 
 ########################################################################################################################
+# CAS Monitoring & Statistics Endpoints
+# See: https://apereo.github.io/cas/6.2.x/monitoring/Monitoring-Statistics.html
+########################################################################################################################
+management.endpoints.web.exposure.include=health
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=WHEN_AUTHORIZED
+cas.monitor.endpoints.endpoint.health.access=ANONYMOUS
+########################################################################################################################
+
+########################################################################################################################
 # CAS Web Application Endpoints Security
 # See: https://docs.spring.io/spring-boot/docs/2.2.8.RELEASE/reference/htmlsingle/#boot-features-security
 # Currently, no sensitive endpoint is exposed. However, set them to prevent auto-generated and logged password


### PR DESCRIPTION
## Ticket

Support https://openscience.atlassian.net/browse/ENG-3773

## Purpose

CAS doesn't not have a status endpoint for health check, which led up to K8s liveness probing using the login endpoint.
We suspect this is what has been causing the CAS pod restarting since the login endpoint may take a while to load. Thus, this PR enables the `/actuator/health` endpoint.

Without detail, it returns HTTP 200 OK with

```json
{
    "status": "UP"
}
```

## Changes

* **Enable** the endpoints as [documented](https://apereo.github.io/cas/6.2.x/monitoring/Monitoring-Statistics.html#cas-endpoints)
* **Configure** the endpoints
```yaml
management.endpoints.web.exposure.include=health
management.endpoint.health.enabled=true
management.endpoint.health.show-details=WHEN_AUTHORIZED
cas.monitor.endpoints.endpoint.health.access=ANONYMOUS
```

## Dev Notes

* None of the default endpoints is ready if enabled but not configured, which is different from what the doc claims.

> Note that by default the only endpoints exposed over the web are info, status, health and configurationMetadata. Other endpoints need to be explicitly enabled and then exposed over the web in CAS settings in order to allow access.

* We use the `/health` endpoint instead of the `/status` endpoint since it is recommened

> Note that /status endpoint is kept mostly as a legacy endpoint. If you wish to obtain health status of each monitor in detail, we recommend the /actuator/health endpoint instead.

## QA Notes

N/A

## Dev-Ops Notes

- [ ] Before CAS deployment, merge the [Charts PR](https://github.com/CenterForOpenScience/helm-charts/pull/79/files)
- [ ] Update K8s liveness probing for CAS to `<CAS Pod IP Address>/actuator/health`
