### PR TITLE
[ENG-3773] Update CAS PAT to the same Never-Expire as OSF PAT

### DIFF
--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -297,6 +297,7 @@ cas.authn.oauth.access-token.crypto.encryption.key=${OAUTH_JWT_ACCESS_TOKEN_ENCR
 cas.authn.oauth.refresh-token.time-to-kill-in-seconds=7776000
 #
 # Personal access token
+# Note: personal access token never expire, neither using the default properties nor setting them here is effective
 #
 cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=31104000
 cas.authn.oauth.personal-access-token.max-time-to-live-in-seconds=31104000

--- a/etc/cas/config/local/cas-local.properties
+++ b/etc/cas/config/local/cas-local.properties
@@ -310,8 +310,9 @@ cas.authn.oauth.access-token.crypto.encryption.key=changeme
 cas.authn.oauth.refresh-token.time-to-kill-in-seconds=2592000
 #
 # Personal access token
+# Note: personal access token never expire, neither using the default properties nor setting them here is effective
 #
-cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=2592000
+cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=31104000
 cas.authn.oauth.personal-access-token.max-time-to-live-in-seconds=31104000
 #
 # Signing and encryption for OAuth registered service

--- a/src/main/java/io/cos/cas/oauth/ticket/support/OsfCasOAuth20PersonalAccessTokenExpirationPolicy.java
+++ b/src/main/java/io/cos/cas/oauth/ticket/support/OsfCasOAuth20PersonalAccessTokenExpirationPolicy.java
@@ -11,21 +11,18 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 
 /**
  * This is {@link OsfCasOAuth20PersonalAccessTokenExpirationPolicy}.
  *
  * Personal access token shares the same implementation class {@link org.apereo.cas.ticket.accesstoken.OAuth20DefaultAccessToken} of access
- * token. Thus, the expiration policy is very similar to {@link org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenExpirationPolicy}.
+ * token. However, since personal access token never expires, its expiration policy is overridden to return {@code false} without going
+ * through the timing checks in {@link org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenExpirationPolicy}.
  *
  * The expiration policy are applied when the personal access token is created from an {@link io.cos.cas.osf.model.OsfOAuth20Pat} with
- * using properties configured via {@link io.cos.cas.oauth.configuration.model.OsfCasOAuth20PersonalAccessTokenProperties}.
+ * using default properties or ones configured via {@link io.cos.cas.oauth.configuration.model.OsfCasOAuth20PersonalAccessTokenProperties}.
+ * However, the properties {@code maxTimeToLiveInSeconds} and {@code timeToKillInSeconds} don't have any effect due to PAT's never expiring.
  *
  * @author Longze Chen
  * @since 21.1.0
@@ -67,26 +64,6 @@ public class OsfCasOAuth20PersonalAccessTokenExpirationPolicy extends AbstractCa
     public boolean isExpired(final TicketState ticketState) {
         if (ticketState == null) {
             LOGGER.debug("Personal access token is considered expired because the ticket state is null");
-            return true;
-        }
-        val currentSystemTime = ZonedDateTime.now(ZoneOffset.UTC);
-        val creationTime = ticketState.getCreationTime();
-        val expirationTime = creationTime.plus(this.maxTimeToLiveInSeconds, ChronoUnit.SECONDS);
-        if (currentSystemTime.isAfter(expirationTime)) {
-            LOGGER.debug(
-                    "Personal access token is expired because the current time [{}] is after the max time to live [{}]",
-                    currentSystemTime,
-                    expirationTime
-            );
-            return true;
-        }
-        val expirationTimeToKill = ticketState.getLastTimeUsed().plus(this.timeToKillInSeconds, ChronoUnit.SECONDS);
-        if (currentSystemTime.isAfter(expirationTimeToKill)) {
-            LOGGER.debug(
-                    "Personal access token is expired because the current time [{}] is after the time to kill [{}]",
-                    currentSystemTime,
-                    expirationTimeToKill
-            );
             return true;
         }
         return false;

--- a/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
+++ b/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
@@ -112,13 +112,13 @@ public class OAuth20UserProfileEndpointController extends BaseOAuth20Controller 
                     .getTicket(personalAccessTokenId, OAuth20AccessToken.class);
         }
         if (accessTokenTicket == null || accessTokenTicket.isExpired()) {
-            // If neither is found nor active, remove unexpired ticket first.
+            // If neither is found nor active, remove expired ticket first.
             LOGGER.debug("Access token [{}] cannot be found in the ticket registry or has expired.", accessTokenId);
             if (accessTokenTicket != null) {
                 LOGGER.debug("Delete expired access token  [{}].", accessTokenId);
                 getOAuthConfigurationContext().getTicketRegistry().deleteTicket(accessTokenTicket);
             }
-            // Then try to create an CAS access token if the token provided is an valid and active OSF personal access token.
+            // Then try to create an CAS access token if the token provided is a valid and active OSF personal access token.
             LOGGER.debug("Check personal access token [{}] in the OSF database.", accessTokenId);
             accessTokenTicket = attemptToGenerateAccessTokenFromOsfPat(accessTokenId);
             // Raise authorization error if all attempts have been failed.


### PR DESCRIPTION
## Ticket

Support https://openscience.atlassian.net/browse/ENG-3773

## Purpose

* Fix postgres insertion error / lock due to CAS PAT artificially expiring in CAS DB.
  * newCAS creates an artificial expiration date (1 year) for PATs while OSF keeps PATs forever. From CAS DB's perspective, PATs inherits from AT, which inherits from ticket. They all use the same design where the ticket/token ID is actually the primary key `id`. Our guess is that the weird locking/integrity issue happens when the same PAT is inserted before the old PAT gets vacuumed or deleted. Thus the fix is to update the expiration policy to never-expire in order to avoid the above glitch. This, in fact, reverts the expiration policy to [what oldCAS did](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/ticket/support/OAuthDelegatingExpirationPolicy.java#L105-L108).

## Changes

* Update `isExpired()` check to return `false`
* Update JavaDoc, comments and (local and copy-of-server) settings

## Dev Notes

Here are some extra tests that we did to test policy change on existing and new PATS.

* The expiration “properties” (i.e. timings) are bound to the PAT once it is created, which is stored in the DB as a LOB.
* The expiration check [`.isExpired()`](https://github.com/CenterForOpenScience/osf-cas/blob/316643d34e67667a13802ce449e939c1108e7239/src/main/java/io/cos/cas/oauth/ticket/support/OsfCasOAuth20PersonalAccessTokenExpirationPolicy.java#L67), though being part of the policy, is not stored in the DB as expected and thus refreshes upon code update.
* This leads to the fact that old PATs will still have the 1-year expiration policy but will not be vacuumed periodically or deleted during access check. This makes sense since any PAT, old or new, have or will still have expiration properties set anyway due to its being a type of token/ticket.
* In short, old PATs will pass expiration check and won’t be deleted or vacuumed; duplicate PATs won’t be inserted again.

## QA Notes

- [ ] DevTest on the test server before prod deployment.

## Dev-Ops Notes

- [x] No settings update is required since the properties don't have any effect.
