### PR TITLE
[ENG-3619] Institution Affiliation via ORCiD SSO - CAS Part

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/support/DelegationProtocol.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/DelegationProtocol.java
@@ -14,7 +14,9 @@ public enum DelegationProtocol {
 
     CAS_PAC4J("cas-pac4j"),
 
-    SAML_SHIB("saml-shib");
+    SAML_SHIB("saml-shib"),
+
+    AFFILIATION_VIA_ORCID("via-orcid");
 
     private final String id;
 

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -22,6 +22,8 @@ import java.util.Map;
 @Slf4j
 public final class OsfInstitutionUtils {
 
+    public final static String ORCID_SUFFIX = " (via ORCiD SSO)";
+
     public static boolean validateInstitutionForLogin(final JpaOsfDao jpaOsfDao, final String id) {
         final OsfInstitution institution = jpaOsfDao.findOneInstitutionById(id);
         return institution != null && institution.getDelegationProtocol() != null;
@@ -53,6 +55,8 @@ public final class OsfInstitutionUtils {
                 );
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(institution.getInstitutionId(), institution.getName());
+            } else if (DelegationProtocol.AFFILIATION_VIA_ORCID.equals(delegationProtocol)) {
+                institutionLoginUrlMap.put(DelegationProtocol.AFFILIATION_VIA_ORCID.getId(), institution.getName() + ORCID_SUFFIX);
             }
         }
         return institutionLoginUrlMap;

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -50,7 +50,7 @@ public final class OsfInstitutionUtils {
             final DelegationProtocol delegationProtocol = institution.getDelegationProtocol();
             if (DelegationProtocol.SAML_SHIB.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(
-                        institution.getLoginUrl() + "&target=" + target + '#' + institution.getId(),
+                        institution.getLoginUrl() + "&target=" + target + '#' + institution.getInstitutionId(),
                         institution.getName()
                 );
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -56,7 +56,10 @@ public final class OsfInstitutionUtils {
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(institution.getInstitutionId(), institution.getName());
             } else if (DelegationProtocol.AFFILIATION_VIA_ORCID.equals(delegationProtocol)) {
-                institutionLoginUrlMap.put(DelegationProtocol.AFFILIATION_VIA_ORCID.getId(), institution.getName() + ORCID_SUFFIX);
+                institutionLoginUrlMap.put(
+                        DelegationProtocol.AFFILIATION_VIA_ORCID.getId() + '#' + institution.getInstitutionId(),
+                        institution.getName() + ORCID_SUFFIX
+                );
             }
         }
         return institutionLoginUrlMap;

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -99,9 +99,9 @@
                         /*<![CDATA[*/
                             institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('cord')}]]*/ '';
                         /*]]>*/
-                    } else if (institutionLoginUrl === "fake-cas-type-5") {
+                    } else if (institutionLoginUrl === "osftype0") {
                         /*<![CDATA[*/
-                        institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('fake-cas-type-5')}]]*/ '';
+                            institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('osftype0')}]]*/ '';
                         /*]]>*/
                     } else if (institutionLoginUrl === "via-orcid") {
                         institutionLoginUrl = /*[[${osfCasLoginContext.orcidLoginUrl}]]*/ ''

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -99,10 +99,12 @@
                         /*<![CDATA[*/
                             institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('cord')}]]*/ '';
                         /*]]>*/
-                    } else if (institutionLoginUrl === "fakecas") {
+                    } else if (institutionLoginUrl === "fake-cas-type-5") {
                         /*<![CDATA[*/
-                            institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('fakecas')}]]*/ '';
+                        institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('fake-cas-type-5')}]]*/ '';
                         /*]]>*/
+                    } else if (institutionLoginUrl === "via-orcid") {
+                        institutionLoginUrl = /*[[${osfCasLoginContext.orcidLoginUrl}]]*/ ''
                     } else {
                         let lastIndexOfHash = institutionLoginUrl.lastIndexOf("#");
                         if (lastIndexOfHash >= 0) {

--- a/src/main/resources/templates/casInstitutionLoginView.html
+++ b/src/main/resources/templates/casInstitutionLoginView.html
@@ -103,7 +103,7 @@
                         /*<![CDATA[*/
                             institutionLoginUrl = /*[[${pac4jInstnLoginUrls.get('osftype0')}]]*/ '';
                         /*]]>*/
-                    } else if (institutionLoginUrl === "via-orcid") {
+                    } else if (institutionLoginUrl.startsWith("via-orcid")) {
                         institutionLoginUrl = /*[[${osfCasLoginContext.orcidLoginUrl}]]*/ ''
                     } else {
                         let lastIndexOfHash = institutionLoginUrl.lastIndexOf("#");


### PR DESCRIPTION
## Ticket

Epic: https://openscience.atlassian.net/browse/ENG-3619
Ticket: https://openscience.atlassian.net/browse/ENG-3623

## Purpose

(Replaces https://github.com/CenterForOpenScience/osf-cas/pull/61)

Update CAS to support institutions of which SSO and affiliation is done via ORCiD.

## Changes

We've chosen the balanced solution out the three in the ticket.

* CAS list `via-orcid` institutions in the drop-down list with extra note "via ORCiD SSO" appended as suffix.
* When clicked, it redirects user to ORCiD login and the rest follow standard ORCiD login flow
* Affiliation is done in OSF and thus out of the scope of this PR

## Dev Notes

N/A

## QA Notes

Refer to the Backend/OSF PR.

## Dev-Ops Notes

- [ ] This PR can be merged without its OSF part: https://github.com/CenterForOpenScience/osf.io/pull/9962. The new feature won't take effect or be visible until the that PR is updated.
