### PR TITLE
[ENG-3654] Update shared SSO to support userRoles

### DIFF
--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -558,6 +558,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
         final String givenName = user.optString("givenName").trim();
         final String familyName = user.optString("familyName").trim();
         final String isMemberOf = user.optString("isMemberOf").trim();
+        final String userRoles = user.optString("userRoles").trim();
         if (username.isEmpty()) {
             LOGGER.error("[CAS XSLT] Missing email (username) for user at institution '{}'", institutionId);
             throw new InstitutionSsoFailedException("Missing email (username)");
@@ -568,13 +569,20 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
         }
         if (!isMemberOf.isEmpty()) {
             LOGGER.info(
-                    "[CAS XSLT] Secondary institution detected: username={}, institution={}, member={}",
+                    "[CAS XSLT] Shared SSO \"isMemberOf\" detected: username={}, institution={}, isMemberOf={}",
                     username,
                     institutionId,
                     isMemberOf
             );
+        } else if (!userRoles.isEmpty()) {
+            LOGGER.info(
+                    "[CAS XSLT] Shared SSO \"userRoles\" detected: username={}, institution={}, userRoles={}",
+                    username,
+                    institutionId,
+                    userRoles
+            );
         } else {
-            LOGGER.debug("[CAS XSLT] Secondary institution is not provided: username={}, institution={}", username, institutionId);
+            LOGGER.debug("[CAS XSLT] Shared SSO not eligible: username={}, institution={}", username, institutionId);
         }
         // Parse the department attribute
         final String departmentRaw = user.optString("departmentRaw").trim();


### PR DESCRIPTION
## Ticket

Supports: https://openscience.atlassian.net/browse/ENG-3654

Primary OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/9977

## Purpose

Update shared SSO to support `userRoles`

## Changes

Changes in this PR do not block the shared SSO feature update since the only code change is log updates. The actual  changes are the attribute mapping (Shibboleth) and normalization (CAS) updates, both of which live in private server settings. Refer to DevOps Notes for details.

```xml
<!--Florida State University (FSU) -->
<xsl:when test="$idp='https://idp.fsu.edu'">
    <id>fsu</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <userRoles><xsl:value-of select="//attribute[@name='userroles']/@value"/></userRoles>
        <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

```xml
<!-- Shared SSO Filter Attribute for FSU and NationalMagLab -->
<Attribute name="urn:fsu:names:SAML:attribute:fsuEduAppRoles" id="userRoles"/>
```

Optional, probably via another PR targeting `develop`, bring local and server (copy) settings up-to-date and add postman tests.

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

See Dev-Ops Notes notes in https://github.com/CenterForOpenScience/osf.io/pull/9977
