### PR TITLE
[ENG-4191] SSO Patch Part 1: Add an extra check for username and its shibboleth attribute during SSO

### DIFF
--- a/etc/cas/config/instn-authn-prod.xsl
+++ b/etc/cas/config/instn-authn-prod.xsl
@@ -239,7 +239,7 @@
                     <xsl:when test="$idp='https://login.iit.edu/cas/idp'">
                         <id>iit</id>
                         <user>
-                            <username><xsl:value-of select="//attribute[@name='email']/@value"/></username>
+                            <username><xsl:value-of select="//attribute[@name='mailother']/@value"/></username>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
                             <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
@@ -397,7 +397,7 @@
                     <xsl:when test="$idp='https://www.rediris.es/sir/csicidp'">
                         <id>csic</id>
                         <user>
-                            <username><xsl:value-of select="//attribute[@name='irismailmainaddress']/@value"/></username>
+                            <username><xsl:value-of select="//attribute[@name='mailother']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='displayname']/@value"/></fullname>
                             <familyName/>
                             <givenName/>
@@ -653,7 +653,7 @@
                     <xsl:when test="$idp='https://shibboleth.usc.edu/shibboleth-idp'">
                         <id>usc</id>
                         <user>
-                            <username><xsl:value-of select="//attribute[@name='uscemailprimaryaddress']/@value"/></username>
+                            <username><xsl:value-of select="//attribute[@name='mailother']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='uscdisplaygivenname']/@value"/><xsl:text> </xsl:text><xsl:value-of select="//attribute[@name='uscdisplaysn']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='uscdisplaysn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='uscdisplaygivenname']/@value"/></givenName>

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -249,6 +249,22 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             final OsfPostgresCredential osfPostgresCredential = constructCredentialsFromShibbolethAuthentication(context, request);
 
             final OsfApiInstitutionAuthenticationResult remoteUserInfo = notifyOsfApiOfInstnAuthnSuccess(osfPostgresCredential);
+            final String ssoEppn = osfPostgresCredential.getDelegationAttributes().get("eppn");
+            final String ssoMail = osfPostgresCredential.getDelegationAttributes().get("mail");
+            final String ssoMailOther = osfPostgresCredential.getDelegationAttributes().get("mailother");
+            if (!remoteUserInfo.verifyOsfUsername(ssoEppn, ssoMail, ssoMailOther)) {
+                LOGGER.error(
+                        "[SAML Shibboleth] Critical Error: eppn={}, mail={}, mailOther={}, entityId={}, username={}, institutionId={}",
+                        ssoEppn,
+                        ssoMail,
+                        ssoMailOther,
+                        osfPostgresCredential.getDelegationAttributes().get("shib-session-id"),
+                        remoteUserInfo.getUsername(),
+                        remoteUserInfo.getInstitutionId()
+                );
+                throw new InstitutionSsoFailedException("Critical SAML-Shibboleth SSO Failure");
+            }
+
             osfPostgresCredential.setUsername(remoteUserInfo.getUsername());
             osfPostgresCredential.setInstitutionId(remoteUserInfo.getInstitutionId());
             if (StringUtils.isBlank(osfPostgresCredential.getInstitutionalIdentity())) {

--- a/src/main/java/io/cos/cas/osf/web/support/OsfApiInstitutionAuthenticationResult.java
+++ b/src/main/java/io/cos/cas/osf/web/support/OsfApiInstitutionAuthenticationResult.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
 
@@ -19,6 +22,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @ToString
 @Setter
+@Slf4j
 public class OsfApiInstitutionAuthenticationResult implements Serializable {
 
     private static final long serialVersionUID = 3971349776123204760L;
@@ -26,4 +30,20 @@ public class OsfApiInstitutionAuthenticationResult implements Serializable {
     private String username;
 
     private String institutionId;
+
+    /**
+     * Verify that the username comes from one of the three attributes in Shibboleth SSO headers.
+     *
+     * @param ssoEppn eppn
+     * @param ssoMail mail
+     * @param ssoMailOther customized attribute for email
+     * @return true if username equals to any of the three else false
+     */
+    public Boolean verifyOsfUsername(final String ssoEppn, final String ssoMail, final String ssoMailOther) {
+        if (StringUtils.isBlank(username)) {
+            LOGGER.error("[CAS XSLT] Username={} is blank", username);
+            return false;
+        }
+        return username.equalsIgnoreCase(ssoEppn) || username.equalsIgnoreCase(ssoMail) || username.equalsIgnoreCase(ssoMailOther);
+    }
 }


### PR DESCRIPTION
## Purpose

See details in https://openscience.atlassian.net/browse/ENG-4191

## DevOps Notes

- [x] Update `attribute-map.xml` in shib and change all three attributes to `d="mailOther"`
  * `id="email"`
  * `id="irismailmainaddress"` (my local copy doesn't have this one though ...)
  * `id="uscEmailPrimaryAddress"`.