### PR TITLE
[ENG-4251] Improve OSF API requests during institution SSO

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/exception/InstitutionSsoOsfApiFailureException.java
+++ b/src/main/java/io/cos/cas/osf/authentication/exception/InstitutionSsoOsfApiFailureException.java
@@ -1,0 +1,30 @@
+package io.cos.cas.osf.authentication.exception;
+
+import lombok.NoArgsConstructor;
+
+import javax.security.auth.login.AccountException;
+
+/**
+ * Describes an authentication error condition when connection failures and/or server errors happen between
+ * CAS and OSF API during institution SSO.
+ *
+ * @author Longze Chen
+ * @since 22.1.3
+ */
+@NoArgsConstructor
+public class InstitutionSsoOsfApiFailureException extends AccountException {
+
+    /**
+     * Serialization metadata.
+     */
+    private static final long serialVersionUID = -620313210360224932L;
+
+    /**
+     * Instantiates a new {@link InstitutionSsoOsfApiFailureException}.
+     *
+     * @param msg the msg
+     */
+    public InstitutionSsoOsfApiFailureException(final String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/config/OsfCasCoreWebflowConfiguration.java
@@ -3,6 +3,7 @@ package io.cos.cas.osf.web.flow.config;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedIdpException;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedOsfException;
 import io.cos.cas.osf.authentication.exception.InstitutionSelectiveSsoFailedException;
+import io.cos.cas.osf.authentication.exception.InstitutionSsoOsfApiFailureException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InvalidOneTimePasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidPasswordException;
@@ -50,6 +51,7 @@ public class OsfCasCoreWebflowConfiguration extends CasCoreWebflowConfiguration 
         errors.add(InvalidVerificationKeyException.class);
         errors.add(OneTimePasswordRequiredException.class);
         errors.add(InstitutionSelectiveSsoFailedException.class);
+        errors.add(InstitutionSsoOsfApiFailureException.class);
         errors.add(TermsOfServiceConsentRequiredException.class);
 
         // Add built-in exceptions after OSF-specific exceptions since order matters

--- a/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/configurer/OsfCasLoginWebflowConfigurer.java
@@ -4,6 +4,7 @@ import io.cos.cas.osf.authentication.credential.OsfPostgresCredential;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedIdpException;
 import io.cos.cas.osf.authentication.exception.AccountNotConfirmedOsfException;
 import io.cos.cas.osf.authentication.exception.InstitutionSelectiveSsoFailedException;
+import io.cos.cas.osf.authentication.exception.InstitutionSsoOsfApiFailureException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InvalidOneTimePasswordException;
 import io.cos.cas.osf.authentication.exception.InvalidUserStatusException;
@@ -265,6 +266,11 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
                 InstitutionSelectiveSsoFailedException.class.getSimpleName(),
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED
         );
+        createTransitionForState(
+                handler,
+                InstitutionSsoOsfApiFailureException.class.getSimpleName(),
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_OSF_API_FAILURE
+        );
 
         // The default transition
         createStateDefaultTransition(handler, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM);
@@ -414,6 +420,11 @@ public class OsfCasLoginWebflowConfigurer extends DefaultLoginWebflowConfigurer 
                 flow,
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED,
                 OsfCasWebflowConstants.VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED
+        );
+        createViewState(
+                flow,
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_OSF_API_FAILURE,
+                OsfCasWebflowConstants.VIEW_ID_INSTITUTION_OSF_API_FAILURE
         );
     }
 

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -92,6 +92,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is {@link OsfPrincipalFromNonInteractiveCredentialsAction}.
@@ -159,6 +160,17 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
     private static final String SHIBBOLETH_COOKIE_PREFIX = "_shibsession_";
 
     private static final String LDAP_DN_OU_PREFIX = "ou=";
+
+    private static final int OSF_API_RETRY_LIMIT = 3;
+
+    private static final List<Integer> OSF_API_RETRY_STATUS = List.of(
+            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+            HttpStatus.SC_BAD_GATEWAY,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_GATEWAY_TIMEOUT
+    );
+
+    private static final int OSF_API_RETRY_DELAY_IN_SECONDS = 1;
 
     @NotNull
     private CentralAuthenticationService centralAuthenticationService;
@@ -672,28 +684,73 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             throw new InstitutionSsoFailedException("OSF CAS failed to build JWT / JWE payload for OSF API");
         }
         // Send the POST request to OSF API to verify an existing institution user or to create a new one
-        int statusCode;
-        HttpResponse httpResponse;
-        try {
-            httpResponse = Request.Post(osfApiProperties.getInstnAuthnEndpoint())
-                    .addHeader(new BasicHeader("Content-Type", "text/plain"))
-                    .bodyString(jweString, ContentType.APPLICATION_JSON)
-                    .execute()
-                    .returnResponse();
-            statusCode = httpResponse.getStatusLine().getStatusCode();
-            LOGGER.info(
-                    "[OSF API] Notify Remote Principal Authenticated Response: username={}, statusCode={}",
-                    username,
-                    statusCode
-            );
-        } catch (final IOException e) {
-            LOGGER.error("[OSF API] Notify Remote Principal Authenticated Failed: Communication Error - {}", e.getMessage());
-            throw new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+        int statusCode = -1;
+        int retry = 0;
+        final String ssoUser = String.format("institution=%s, username=%s", institutionId, username);
+        HttpResponse httpResponse = null;
+        InstitutionSsoFailedException casError = null;
+        while (retry < OSF_API_RETRY_LIMIT) {
+            retry += 1;
+            // Reset exception from previous attempt
+            casError = null;
+            try {
+                httpResponse = Request.Post(osfApiProperties.getInstnAuthnEndpoint())
+                        .addHeader(new BasicHeader("Content-Type", "text/plain"))
+                        .bodyString(jweString, ContentType.APPLICATION_JSON)
+                        .execute()
+                        .returnResponse();
+                statusCode = httpResponse.getStatusLine().getStatusCode();
+                LOGGER.info(
+                        "[OSF API] Notify Remote Principal Authenticated Response Received: {}, attempt={}, status={}",
+                        ssoUser,
+                        retry,
+                        statusCode
+                );
+                // CAS expects OSF API to return HTTP 204 OK with no content if authentication succeeds
+                if (statusCode == HttpStatus.SC_NO_CONTENT) {
+                    LOGGER.info(
+                            "[OSF API] Notify Remote Principal Authenticated Passed: {}, attempt={}, status={}",
+                            ssoUser,
+                            retry,
+                            statusCode
+                    );
+                    return new OsfApiInstitutionAuthenticationResult(username, institutionId);
+                }
+                if (OSF_API_RETRY_STATUS.contains(statusCode)) {
+                    LOGGER.error(
+                            "[OSF API] Notify Remote Principal Authenticated Failed - Server Error: {}, attempt={}, status={}",
+                            ssoUser,
+                            retry,
+                            statusCode
+                    );
+                    casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+                } else {
+                    break;
+                }
+            } catch (final IOException e) {
+                LOGGER.error(
+                        "[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: {}, attempt={}, error={}",
+                        ssoUser,
+                        retry,
+                        e.getMessage()
+                );
+                casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+            }
+            try {
+                TimeUnit.SECONDS.sleep(OSF_API_RETRY_DELAY_IN_SECONDS * retry);
+            } catch (InterruptedException e) {
+                LOGGER.error(
+                        "[OSF API] Notify Remote Principal Authenticated Failed - Retry Interrupted: {}, attempt={}, error={}",
+                        ssoUser,
+                        retry,
+                        e.getMessage()
+                );
+                casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+                break;
+            }
         }
-        // CAS expects OSF API to return HTTP 204 OK with no content if authentication succeeds
-        if (statusCode == HttpStatus.SC_NO_CONTENT) {
-            LOGGER.info("[OSF API] Notify Remote Principal Authenticated Passed: institution={}, username={}", institutionId, username);
-            return new OsfApiInstitutionAuthenticationResult(username, institutionId);
+        if (casError != null) {
+            throw casError;
         }
         // Handler unexpected exceptions (i.e. any status other than 403)
         if (statusCode != HttpStatus.SC_FORBIDDEN) {

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonParser;
 import io.cos.cas.osf.authentication.credential.OsfPostgresCredential;
 import io.cos.cas.osf.authentication.exception.InstitutionSelectiveSsoFailedException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoFailedException;
+import io.cos.cas.osf.authentication.exception.InstitutionSsoOsfApiFailureException;
 import io.cos.cas.osf.authentication.support.DelegationProtocol;
 import io.cos.cas.osf.authentication.support.OsfApiPermissionDenied;
 import io.cos.cas.osf.configuration.model.OsfApiProperties;
@@ -688,7 +689,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
         int retry = 0;
         final String ssoUser = String.format("institution=%s, username=%s", institutionId, username);
         HttpResponse httpResponse = null;
-        InstitutionSsoFailedException casError = null;
+        InstitutionSsoOsfApiFailureException casError = null;
         while (retry < OSF_API_RETRY_LIMIT) {
             retry += 1;
             // Reset exception from previous attempt
@@ -723,7 +724,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                             retry,
                             statusCode
                     );
-                    casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+                    casError = new InstitutionSsoOsfApiFailureException("Communication Error between OSF CAS and OSF API");
                 } else {
                     break;
                 }
@@ -734,7 +735,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                         retry,
                         e.getMessage()
                 );
-                casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+                casError = new InstitutionSsoOsfApiFailureException("Communication Error between OSF CAS and OSF API");
             }
             try {
                 TimeUnit.SECONDS.sleep(OSF_API_RETRY_DELAY_IN_SECONDS * retry);
@@ -745,7 +746,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                         retry,
                         e.getMessage()
                 );
-                casError = new InstitutionSsoFailedException("Communication Error between OSF CAS and OSF API");
+                casError = new InstitutionSsoOsfApiFailureException("Communication Error between OSF CAS and OSF API");
                 break;
             }
         }

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -696,6 +696,8 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             casError = null;
             try {
                 httpResponse = Request.Post(osfApiProperties.getInstnAuthnEndpoint())
+                        .connectTimeout(SIXTY_SECONDS)
+                        .socketTimeout(SIXTY_SECONDS)
                         .addHeader(new BasicHeader("Content-Type", "text/plain"))
                         .bodyString(jweString, ContentType.APPLICATION_JSON)
                         .execute()

--- a/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/support/OsfCasWebflowConstants.java
@@ -64,5 +64,7 @@ public interface OsfCasWebflowConstants {
 
     String VIEW_ID_INSTITUTION_SELECTIVE_SSO_FAILED = "casInstitutionSelectiveSsoFailedView";
 
+    String VIEW_ID_INSTITUTION_OSF_API_FAILURE = "casInstitutionOsfApiFailureView";
+
     String VIEW_ID_OAUTH_20_ERROR_VIEW = "casOAuth20ErrorView";
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -693,6 +693,9 @@ screen.institutionssofailed.message=Your request cannot be completed at this tim
 screen.institutionselectivessofailed.message=Your institutional account is unable to authenticate to OSF. \
   Please check with your institution. If your institution believes this is in error, please contact \
   <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
+screen.institutionosfapifailure.message=Your request cannot be completed at this time due to an unexpected error. Please \
+  <a style="white-space: nowrap" href="{0}">return to OSF</a> and try again later.</br></br>If the issue persists, \
+  please contact <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
 #
 # OAuth 2.0 Views and Error Views
 #

--- a/src/main/resources/templates/casInstitutionOsfApiFailureView.html
+++ b/src/main/resources/templates/casInstitutionOsfApiFailureView.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layoutosf}">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+    <title th:text="#{screen.institutionssofailed.title}"></title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+</head>
+
+<body class="mdc-typography">
+<div layout:fragment="content" class="d-flex justify-content-center">
+
+    <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
+        <section class="login-error-card">
+            <section>
+                <div th:replace="fragments/osfbannerui :: osfBannerUI">
+                    <a href="fragments/osfbannerui.html"></a>
+                </div>
+            </section>
+            <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
+                <span th:utext="#{screen.authnerror.tips}"></span>
+            </section>
+            <hr class="my-4" />
+            <section class="card-message">
+                <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
+                <p th:utext="#{screen.institutionosfapifailure.message}"></p>
+            </section>
+            <section class="form-button">
+                <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=${osfUrl.logout})}">
+                    <span class="mdc-button__label" th:utext="#{screen.authnerror.button.backtoosf}"></span>
+                </a>
+            </section>
+            <hr class="my-4" />
+            <section class="text-with-mdi" th:with="loginUrl=@{${@casServerLoginUrl}(casRedirectSource=cas)}">
+                <span><a th:href="@{/logout(service=${loginUrl})}" th:utext="#{screen.error.page.loginagain}"></a></span>
+            </section>
+        </section>
+    </div>
+
+    <script type="text/javascript">
+        disableSignUpButton();
+    </script>
+
+</div>
+</body>
+
+</html>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-4251

## Purpose

Improve OSF API requests during institution SSO

## Changes

* Added manual retries for API requests failure due to connection and/or server errors
* Created a new exception flow for the above so that users are properly informed when they encounter such failures
* Added connection and socket timeout for API requests

## Dev Notes

A few testing logs

```
2022-12-20 10:09:37,258 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=user1@type8.osf.io, institution=osftype8>
2022-12-20 10:10:37,283 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=1, error=Read timed out>
2022-12-20 10:11:38,295 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=2, error=Read timed out>
2022-12-20 10:12:40,361 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=3, error=Read timed out>
2022-12-20 10:12:43,364 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <Action execution disallowed; pre-execution result is 'authenticationFailure'>

2022-12-20 10:15:56,390 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=user1@type8.osf.io, institution=osftype8>
2022-12-20 10:16:13,156 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=1, error=192.168.168.167:8000 failed to respond>
2022-12-20 10:16:14,151 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=2, error=192.168.168.167:8000 failed to respond>
2022-12-20 10:16:16,160 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Communication Error: institution=osftype8, username=user1@type8.osf.io, attempt=3, error=192.168.168.167:8000 failed to respond>
2022-12-20 10:16:19,160 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <Action execution disallowed; pre-execution result is 'authenticationFailure'>

2022-12-20 10:19:47,775 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=user1@type8.osf.io, institution=osftype8>
2022-12-20 10:19:52,216 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response Received: institution=osftype8, username=user1@type8.osf.io, attempt=1, status=503>
2022-12-20 10:19:52,217 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Server Error: institution=osftype8, username=user1@type8.osf.io, attempt=1, status=503>
2022-12-20 10:19:57,258 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response Received: institution=osftype8, username=user1@type8.osf.io, attempt=2, status=503>
2022-12-20 10:19:57,258 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Server Error: institution=osftype8, username=user1@type8.osf.io, attempt=2, status=503>
2022-12-20 10:20:03,377 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response Received: institution=osftype8, username=user1@type8.osf.io, attempt=3, status=503>
2022-12-20 10:20:03,377 ERROR [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Failed - Server Error: institution=osftype8, username=user1@type8.osf.io, attempt=3, status=503>
2022-12-20 10:20:06,378 INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <Action execution disallowed; pre-execution result is 'authenticationFailure'>
```

## QA Notes

Here is the error page with updated instructions

<img width="726" alt="Screen Shot 2022-12-20 at 6 17 02 AM" src="https://user-images.githubusercontent.com/3750414/208654587-0c420c17-7267-467d-96db-0757c4b2da85.png">

## Dev-Ops Notes

No configuration updates. Just merge and deploy!
