### PR TITLE
[ENG-4436] Customize SSO Error Handling

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -29,6 +29,11 @@ public final class OsfInstitutionUtils {
         return institution != null && institution.getDelegationProtocol() != null;
     }
 
+    public static String getInstitutionSupportEmail(final JpaOsfDao jpaOsfDao, final String id) {
+        final OsfInstitution institution = jpaOsfDao.findOneInstitutionById(id);
+        return institution != null ? institution.getSupportEmail() : null;
+    }
+
     public static Map<String, String> getInstitutionLoginUrlMap(
             final JpaOsfDao jpaOsfDao,
             final String target,

--- a/src/main/java/io/cos/cas/osf/model/OsfInstitution.java
+++ b/src/main/java/io/cos/cas/osf/model/OsfInstitution.java
@@ -50,6 +50,9 @@ public class OsfInstitution extends AbstractOsfModel {
     @Column(name = "deactivated")
     private Date dateDeactivated;
 
+    @Column(name = "support_email", nullable = false)
+    private String supportEmail;
+
     public DelegationProtocol getDelegationProtocol() {
         try {
             return DelegationProtocol.getType(delegationProtocol);

--- a/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
@@ -100,6 +100,7 @@ public class OsfCasSupportActionsConfiguration extends CasSupportActionsConfigur
                 serviceTicketRequestWebflowEventResolver.getObject(),
                 adaptiveAuthenticationPolicy.getObject(),
                 centralAuthenticationService.getObject(),
+                jpaOsfDao.getObject(),
                 casProperties.getAuthn().getOsfUrl(),
                 casProperties.getAuthn().getOsfApi(),
                 authnDelegationClients

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfDefaultLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfDefaultLoginPreparationAction.java
@@ -17,8 +17,6 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.io.Serializable;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 
@@ -55,8 +53,6 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
         final boolean unsupportedInstitutionLogin = isUnsupportedInstitutionLogin(context);
         final boolean orcidRedirect = isOrcidLoginAutoRedirect(context);
         final String orcidLoginUrl = getOrcidLoginUrlFromFlowScope(context);
-
-        final String encodedServiceUrl = getEncodedServiceUrlFromRequestContext(context);
         final boolean defaultService = isFromFlowlessErrorPage(context);
         final OsfUrlProperties osfUrl = Optional.of(context).map(
                 requestContext -> (OsfUrlProperties) requestContext.getFlowScope().get(OsfCasWebflowConstants.FLOW_PARAMETER_OSF_URL)
@@ -72,7 +68,6 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
                 -> (OsfCasLoginContext) requestContext.getFlowScope().get(PARAMETER_LOGIN_CONTEXT)).orElse(null);
         if (loginContext == null) {
             loginContext = new OsfCasLoginContext(
-                    encodedServiceUrl,
                     institutionLogin,
                     institutionId,
                     StringUtils.EMPTY,
@@ -83,7 +78,6 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
                     defaultServiceUrl
             );
         } else {
-            loginContext.setEncodedServiceUrl(encodedServiceUrl);
             loginContext.setInstitutionLogin(institutionLogin);
             loginContext.setInstitutionId(institutionId);
             loginContext.setInstitutionSupportEmail(StringUtils.EMPTY);
@@ -148,14 +142,6 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
             }
         }
         return null;
-    }
-
-    private String getEncodedServiceUrlFromRequestContext(final RequestContext context) throws AssertionError {
-        final String serviceUrl = context.getRequestParameters().get(PARAMETER_SERVICE);
-        if (StringUtils.isBlank(serviceUrl)) {
-            return null;
-        }
-        return URLEncoder.encode(serviceUrl, StandardCharsets.UTF_8);
     }
 
     private boolean isFromFlowlessErrorPage(final RequestContext context) {

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfDefaultLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfDefaultLoginPreparationAction.java
@@ -75,6 +75,7 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
                     encodedServiceUrl,
                     institutionLogin,
                     institutionId,
+                    StringUtils.EMPTY,
                     unsupportedInstitutionLogin,
                     orcidRedirect,
                     orcidLoginUrl,
@@ -85,6 +86,7 @@ public class OsfDefaultLoginPreparationAction extends OsfAbstractLoginPreparatio
             loginContext.setEncodedServiceUrl(encodedServiceUrl);
             loginContext.setInstitutionLogin(institutionLogin);
             loginContext.setInstitutionId(institutionId);
+            loginContext.setInstitutionSupportEmail(StringUtils.EMPTY);
             loginContext.setUnsupportedInstitutionLogin(unsupportedInstitutionLogin);
             loginContext.setOrcidLoginUrl(orcidLoginUrl);
             loginContext.setOrcidRedirect(false);

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
@@ -82,8 +82,9 @@ public class OsfInstitutionLoginPreparationAction extends OsfAbstractLoginPrepar
                 institutionId = null;
             } else {
                 final String institutionSupportEmail = OsfInstitutionUtils.getInstitutionSupportEmail(jpaOsfDao, institutionId);
-                if (institutionSupportEmail != null)
-                loginContext.setInstitutionSupportEmail(institutionSupportEmail);
+                if (institutionSupportEmail != null) {
+                    loginContext.setInstitutionSupportEmail(institutionSupportEmail);
+                }
             }
         }
 

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfInstitutionLoginPreparationAction.java
@@ -80,6 +80,10 @@ public class OsfInstitutionLoginPreparationAction extends OsfAbstractLoginPrepar
                 loginContext.setInstitutionId(null);
                 context.getFlowScope().put(PARAMETER_LOGIN_CONTEXT, loginContext);
                 institutionId = null;
+            } else {
+                final String institutionSupportEmail = OsfInstitutionUtils.getInstitutionSupportEmail(jpaOsfDao, institutionId);
+                if (institutionSupportEmail != null)
+                loginContext.setInstitutionSupportEmail(institutionSupportEmail);
             }
         }
 

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -18,6 +18,7 @@ import io.cos.cas.osf.authentication.support.OsfApiPermissionDenied;
 import io.cos.cas.osf.configuration.model.OsfApiProperties;
 import io.cos.cas.osf.configuration.model.OsfUrlProperties;
 import io.cos.cas.osf.web.support.OsfApiInstitutionAuthenticationResult;
+import io.cos.cas.osf.web.support.OsfCasSsoErrorContext;
 
 import com.nimbusds.jose.crypto.DirectEncrypter;
 import com.nimbusds.jose.crypto.MACSigner;
@@ -140,6 +141,8 @@ import java.util.concurrent.TimeUnit;
 @Setter
 @Getter
 public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNonInteractiveCredentialsAction {
+
+    private static final String PARAMETER_SSO_ERROR_CONTEXT = "osfSsoErrorContext";
 
     private static final String USERNAME_PARAMETER_NAME = "username";
 
@@ -809,5 +812,36 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             return "";
         }
         return "";
+    }
+
+    /**
+     * Prepare {@link OsfCasSsoErrorContext} and put it in flow.
+     *
+     * @param context the request context
+     * @param handleErrorName the error name
+     * @param errorMessage the error message
+     * @param ssoEmail user's SSO email
+     * @param ssoIdentity user's SSO identity
+     * @param institutionId institution ID
+     * @param institutionSupportEmail institution support email
+     */
+    private void setSsoErrorContext(
+            final RequestContext context,
+            final String handleErrorName,
+            final String errorMessage,
+            final String ssoEmail,
+            final String ssoIdentity,
+            final String institutionId,
+            final String institutionSupportEmail
+    ) {
+        OsfCasSsoErrorContext ssoErrorContext =  new OsfCasSsoErrorContext(
+                handleErrorName,
+                errorMessage,
+                ssoEmail,
+                ssoIdentity,
+                institutionId,
+                institutionSupportEmail
+        );
+        context.getFlowScope().put(PARAMETER_SSO_ERROR_CONTEXT, ssoErrorContext);
     }
 }

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -15,8 +15,10 @@ import io.cos.cas.osf.authentication.exception.InstitutionSsoSelectiveLoginDenie
 import io.cos.cas.osf.authentication.exception.InstitutionSsoOsfApiFailedException;
 import io.cos.cas.osf.authentication.support.DelegationProtocol;
 import io.cos.cas.osf.authentication.support.OsfApiPermissionDenied;
+import io.cos.cas.osf.authentication.support.OsfInstitutionUtils;
 import io.cos.cas.osf.configuration.model.OsfApiProperties;
 import io.cos.cas.osf.configuration.model.OsfUrlProperties;
+import io.cos.cas.osf.dao.JpaOsfDao;
 import io.cos.cas.osf.web.support.OsfApiInstitutionAuthenticationResult;
 import io.cos.cas.osf.web.support.OsfCasSsoErrorContext;
 
@@ -142,7 +144,7 @@ import java.util.concurrent.TimeUnit;
 @Getter
 public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNonInteractiveCredentialsAction {
 
-    private static final String PARAMETER_SSO_ERROR_CONTEXT = "osfSsoErrorContext";
+    private static final String PARAMETER_SSO_ERROR_CONTEXT = "osfCasSsoErrorContext";
 
     private static final String USERNAME_PARAMETER_NAME = "username";
 
@@ -183,6 +185,9 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
     private CentralAuthenticationService centralAuthenticationService;
 
     @NotNull
+    private final JpaOsfDao jpaOsfDao;
+
+    @NotNull
     private OsfUrlProperties osfUrlProperties;
 
     @NotNull
@@ -198,6 +203,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             final CasWebflowEventResolver serviceTicketRequestWebflowEventResolver,
             final AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy,
             final CentralAuthenticationService centralAuthenticationService,
+            final JpaOsfDao jpaOsfDao,
             final OsfUrlProperties osfUrlProperties,
             final OsfApiProperties osfApiProperties,
             final Map<String, List<String>> authnDelegationClients
@@ -208,6 +214,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                 adaptiveAuthenticationPolicy
         );
         this.centralAuthenticationService = centralAuthenticationService;
+        this.jpaOsfDao = jpaOsfDao;
         this.osfUrlProperties = osfUrlProperties;
         this.osfApiProperties = osfApiProperties;
         this.authnDelegationClients = authnDelegationClients;
@@ -243,7 +250,8 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                     );
                     final OsfPostgresCredential osfPostgresCredential = constructCredentialsFromPac4jAuthentication(context, clientName);
                     if (osfPostgresCredential != null) {
-                        final OsfApiInstitutionAuthenticationResult remoteUserInfo = notifyOsfApiOfInstnAuthnSuccess(osfPostgresCredential);
+                        final OsfApiInstitutionAuthenticationResult remoteUserInfo
+                                = notifyOsfApiOfInstnAuthnSuccess(context, osfPostgresCredential);
                         osfPostgresCredential.setUsername(remoteUserInfo.getSsoEmail());
                         osfPostgresCredential.setInstitutionId(remoteUserInfo.getInstitutionId());
                         WebUtils.removeCredential(context);
@@ -266,7 +274,8 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             // Type 3: institution sso via Shibboleth authentication using the SAML protocol
             LOGGER.debug("Shibboleth session / header found in request context.");
             final OsfPostgresCredential osfPostgresCredential = constructCredentialsFromShibbolethAuthentication(context, request);
-            final OsfApiInstitutionAuthenticationResult remoteUserInfo = notifyOsfApiOfInstnAuthnSuccess(osfPostgresCredential);
+            final OsfApiInstitutionAuthenticationResult remoteUserInfo
+                    = notifyOsfApiOfInstnAuthnSuccess(context, osfPostgresCredential);
             final String ssoIdentity = osfPostgresCredential.getSsoIdentity();
             final String eppn = osfPostgresCredential.getDelegationAttributes().get("eppn");
             final String mail = osfPostgresCredential.getDelegationAttributes().get("mail");
@@ -571,6 +580,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
      * @throws AccountException if there is an issue with authentication data or if the OSF API request has failed
      */
     private OsfApiInstitutionAuthenticationResult notifyOsfApiOfInstnAuthnSuccess(
+            final RequestContext context,
             final OsfPostgresCredential credential
     ) throws AccountException {
 
@@ -761,6 +771,15 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                 final String errorDetail = ((JsonObject) error).get("detail").getAsString();
                 if (OsfApiPermissionDenied.INSTITUTION_SSO_SELECTIVE_LOGIN_DENIED.getId().equals(errorDetail)) {
                     LOGGER.error("[OSF API] Failure - Institution Selective SSO Not Allowed: {}, filter={}", ssoUser, selectiveSsoFilter);
+                    setSsoErrorContext(
+                            context,
+                            InstitutionSsoSelectiveLoginDeniedException.class.getSimpleName(),
+                            String.format("Institution Selective SSO Not Allowed: %s", ssoUser),
+                            ssoEmail,
+                            ssoIdentity,
+                            institutionId,
+                            OsfInstitutionUtils.getInstitutionSupportEmail(this.jpaOsfDao, institutionId)
+                    );
                     throw new InstitutionSsoSelectiveLoginDeniedException("OSF API denies selective SSO login");
                 }
                 if (OsfApiPermissionDenied.INSTITUTION_SSO_DUPLICATE_IDENTITY.getId().equals(errorDetail)) {

--- a/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
+++ b/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
@@ -26,16 +26,6 @@ public class OsfCasLoginContext implements Serializable  {
 
     private static final long serialVersionUID = 7523144720609509742L;
 
-    /**
-     * The encoded service URL provided by the "service=" query param in the request URL.
-     *
-     * This attribute is deprecated and should be removed since 1) ThymeLeaf handles URL building elegantly in the template and 2) both of
-     * the flow parameters "service.originalUrl" and "originalUrl" stores the current service information.
-     */
-    private String encodedServiceUrl;
-
-    private String handleErrorName;
-
     private boolean institutionLogin;
 
     private String institutionId;
@@ -56,27 +46,4 @@ public class OsfCasLoginContext implements Serializable  {
      * e.g. http(s)://[OSF Domain]/login?next=[encoded version of http(s)://[OSF Domain]/]
      */
     private String defaultServiceUrl;
-
-    public OsfCasLoginContext (
-            final String encodedServiceUrl,
-            final boolean institutionLogin,
-            final String institutionId,
-            final String institutionSupportEmail,
-            final boolean unsupportedInstitutionLogin,
-            final boolean orcidRedirect,
-            final String orcidLoginUrl,
-            final boolean defaultService,
-            final String defaultServiceUrl
-    ) {
-        this.encodedServiceUrl = encodedServiceUrl;
-        this.handleErrorName = null;
-        this.institutionLogin = institutionLogin;
-        this.institutionId = institutionId;
-        this.institutionSupportEmail = institutionSupportEmail;
-        this.unsupportedInstitutionLogin = unsupportedInstitutionLogin;
-        this.orcidRedirect = orcidRedirect;
-        this.orcidLoginUrl = orcidLoginUrl;
-        this.defaultService = defaultService;
-        this.defaultServiceUrl = defaultServiceUrl;
-    }
 }

--- a/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
+++ b/src/main/java/io/cos/cas/osf/web/support/OsfCasLoginContext.java
@@ -40,6 +40,8 @@ public class OsfCasLoginContext implements Serializable  {
 
     private String institutionId;
 
+    private String institutionSupportEmail;
+
     private boolean unsupportedInstitutionLogin;
 
     private boolean orcidRedirect;
@@ -59,6 +61,7 @@ public class OsfCasLoginContext implements Serializable  {
             final String encodedServiceUrl,
             final boolean institutionLogin,
             final String institutionId,
+            final String institutionSupportEmail,
             final boolean unsupportedInstitutionLogin,
             final boolean orcidRedirect,
             final String orcidLoginUrl,
@@ -69,6 +72,7 @@ public class OsfCasLoginContext implements Serializable  {
         this.handleErrorName = null;
         this.institutionLogin = institutionLogin;
         this.institutionId = institutionId;
+        this.institutionSupportEmail = institutionSupportEmail;
         this.unsupportedInstitutionLogin = unsupportedInstitutionLogin;
         this.orcidRedirect = orcidRedirect;
         this.orcidLoginUrl = orcidLoginUrl;

--- a/src/main/java/io/cos/cas/osf/web/support/OsfCasSsoErrorContext.java
+++ b/src/main/java/io/cos/cas/osf/web/support/OsfCasSsoErrorContext.java
@@ -1,0 +1,40 @@
+package io.cos.cas.osf.web.support;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link OsfCasSsoErrorContext}.
+ *
+ * Stores detailed error information, which can be prepared and put into flow before raising an exception. Extends {@link Serializable}
+ * so that it can be put into and retrieved from the flow context conveniently.
+ *
+ * @author Longze Chen
+ * @since 23.2.0
+ */
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+@ToString
+@Setter
+public class OsfCasSsoErrorContext implements Serializable  {
+
+    private static final long serialVersionUID = -1366351087792035267L;
+
+    private String handleErrorName;
+
+    private String errorMessage;
+
+    private String ssoEmail;
+
+    private String ssoIdentity;
+
+    private String institutionId;
+
+    private String institutionSupportEmail;
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -708,10 +708,15 @@ screen.institutionssoattributeparsingfailed.message=\
 screen.institutionssoduplicateidentity.message=\
   Your request cannot be completed at this time due to an error caused by duplicate SSO identity. \
   Please contact <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
-screen.institutionssoselectivelogindenied.message=\
+screen.institutionssoselectivelogindenied.standard.message=\
   Your institutional account is unable to authenticate to OSF. Please check with your institution. \
   If your institution believes this is in error, \
   contact <a style="white-space: nowrap" href="mailto:support@osf.io">Support</a> for help.
+screen.institutionssoselectivelogindenied.support.message=\
+  Your institutional account is unable to authenticate to OSF. \
+  Please contact <a style="white-space: nowrap" href="mailto:{0}">support at your institution</a> first. \
+  If your institution believes this is in error, \
+  contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> for help.
 screen.institutionssoosfapifailed.message=\
   Your request cannot be completed at this time due to an unexpected error. \
   Please <a style="white-space: nowrap" href="{0}">return to OSF</a> and try again later. \

--- a/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
+++ b/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
@@ -25,7 +25,8 @@
                 <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
-                    <p th:utext="#{screen.institutionssoselectivelogindenied.message}"></p>
+                    <p th:if="${#strings.isEmpty(osfCasSsoErrorContext.institutionSupportEmail)}" th:utext="#{screen.institutionssoselectivelogindenied.standard.message}"></p>
+                    <p th:unless="${#strings.isEmpty(osfCasSsoErrorContext.institutionSupportEmail)}" th:utext="#{screen.institutionssoselectivelogindenied.support.message(${osfCasSsoErrorContext.institutionSupportEmail})}"></p>
                 </section>
                 <section class="form-button">
                     <a class="mdc-button mdc-button--raised button-osf-blue" th:href="@{/logout(service=${osfUrl.logout})}">


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-4436

Blocked by: https://openscience.atlassian.net/browse/ENG-4538

## Purpose

Provide an support email to the users when they fail SSO due to selective SSO rules (if their institution has provided a support email)

![support](https://github.com/CenterForOpenScience/osf-cas/assets/3750414/c0e172dc-1a5b-4656-8716-03e22f4c7512)

![standard](https://github.com/CenterForOpenScience/osf-cas/assets/3750414/a7f59901-9dde-4821-8022-83222f6278cf)

## Changes

### Base

* Added `OsfCasSsoErrorContext` to store and send data to the error flow
* Added `JpaOsfDao` access to `OsfPrincipalFromNonInteractiveCredentialsAction`
* Sent data to page via the error context when institution SSO failed

### Institution

* Added `supportEmail` to `OSFInstitution`
* Provide an support email to the users when they fail SSO due to selective SSO rules (if their institution has provided a support email)

## DevOps Notes

Must be merged and deployed after: https://github.com/CenterForOpenScience/osf.io/pull/10402

## QA Notes

N/A (Can't be tested by QA)
