### PR TITLE
Fix an SSO bug where the wrong error is thrown for inactive users

### DIFF
--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 import io.cos.cas.osf.authentication.credential.OsfPostgresCredential;
+import io.cos.cas.osf.authentication.exception.InstitutionSsoAccountInactiveException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoAttributeMissingException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoAttributeParsingException;
 import io.cos.cas.osf.authentication.exception.InstitutionSsoDuplicateIdentityException;
@@ -788,7 +789,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                 }
                 if (OsfApiPermissionDenied.INSTITUTION_SSO_ACCOUNT_INACTIVE.getId().equals(errorDetail)) {
                     LOGGER.error("[OSF API] Failure - Inactive Account: {}", ssoUser);
-                    throw new InstitutionSsoDuplicateIdentityException("OSF API denies inactive account");
+                    throw new InstitutionSsoAccountInactiveException("OSF API denies inactive account");
                 }
             }
             // Handle unidentified HTTP 403 FORBIDDEN failures


### PR DESCRIPTION
## Ticket

N/A

## Purpose

Fix [an SSO bug](https://github.com/CenterForOpenScience/osf-cas/blob/f5dc03eebeaaac9e0fff800e7eea47f74eeb7e63/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java#L791) where the wrong error is thrown for inactive users

## Changes

Use the correct exception `InstitutionSsoAccountInactiveException`

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A
