### PR TITLE
[ENG-6082] Fix two-factor authentication after Python 3.12 upgrade

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
+++ b/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
@@ -165,13 +165,15 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
             if (oneTimePassword == null) {
                 throw new OneTimePasswordRequiredException("2FA TOTP required for user [" + username + "]");
             }
+            final long transformedOneTimePassword = Long.parseLong(oneTimePassword);
+            boolean checkPassed;
             try {
-                final long transformedOneTimePassword = Long.parseLong(oneTimePassword);
-                if (!TotpUtils.checkCode(osfTotp.getTotpSecretBase32(), transformedOneTimePassword)) {
-                    throw new InvalidOneTimePasswordException("Invalid 2FA TOTP for user [" + username + "] (Type 1)");
-                }
-            } catch (final Exception e) {
+                checkPassed = TotpUtils.checkCode(osfTotp.getTotpSecretBase32(), transformedOneTimePassword);
+            } catch (final Exception e){
                 throw new InvalidOneTimePasswordException("Invalid 2FA TOTP for user [" + username + "] (Type 2)");
+            }
+            if (!checkPassed) {
+                throw new InvalidOneTimePasswordException("Invalid 2FA TOTP for user [" + username + "] (Type 1)");
             }
         }
 

--- a/src/main/java/io/cos/cas/osf/model/OsfTotp.java
+++ b/src/main/java/io/cos/cas/osf/model/OsfTotp.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.codec.binary.Base32;
 
@@ -28,6 +29,7 @@ import java.util.Date;
 @NoArgsConstructor
 @Getter
 @ToString
+@Slf4j
 public class OsfTotp extends AbstractOsfModel {
 
     @OneToOne
@@ -50,8 +52,14 @@ public class OsfTotp extends AbstractOsfModel {
     }
 
     public String getTotpSecretBase32() {
-        final byte[] bytes = DatatypeConverter.parseHexBinary(totpSecret);
-        return new Base32().encodeAsString(bytes);
+        try {
+            // Handle totpSecret generated before OSF Python 3.12 upgrade
+            final byte[] bytes = DatatypeConverter.parseHexBinary(totpSecret);
+            return new Base32().encodeAsString(bytes);
+        } catch (final IllegalArgumentException e) {
+            // Handle totpSecret generated after OSF Python 3.12 upgrade
+            return new Base32().encodeAsString(totpSecret.getBytes());
+        }
     }
 
     public boolean isActive() {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-6082

## Purpose

Fix two-factor authentication after Python 3.12 upgrade

## Changes

* Supports `totp_secret` in both HEX and plain string format
* Improved exception handling

## Dev Notes

N/A

## QA Notes

* Test existing 2FA works
* Test newly created 2FA works

## Dev-Ops Notes

N/A
