### PR TITLE
[ENG-8792] Force CAS to throw exceptions and display error pages

### DIFF
--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -151,6 +151,8 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
 
     private static final String VERIFICATION_KEY_PARAMETER_NAME = "verification_key";
 
+    private static final String FORCE_EXCEPTION_PARAMETER_NAME = "forceException";
+
     private static final String OSF_URL_FLOW_PARAMETER = "osfUrl";
 
     private static final String AUTHENTICATION_EXCEPTION = "authnError";
@@ -321,6 +323,20 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
             return constructCredentialsFromUsernameAndVerificationKey(username, verificationKey);
         }
         LOGGER.debug("No valid username or verification key found in request parameters.");
+
+        final String forcedException = request.getParameter(FORCE_EXCEPTION_PARAMETER_NAME);
+        if (StringUtils.isNotBlank(forcedException)) {
+            if (OsfApiPermissionDenied.INSTITUTION_SSO_ACCOUNT_INACTIVE.getId().equals(forcedException)) {
+                throw new InstitutionSsoAccountInactiveException();
+            }
+            if (OsfApiPermissionDenied.INSTITUTION_SSO_DUPLICATE_IDENTITY.getId().equals(forcedException)) {
+                throw new InstitutionSsoDuplicateIdentityException();
+            }
+            if (OsfApiPermissionDenied.INSTITUTION_SSO_SELECTIVE_LOGIN_DENIED.getId().equals(forcedException)) {
+                throw new InstitutionSsoSelectiveLoginDeniedException();
+            }
+            // Add more if statement to force throw desired exceptions and displays respective error pages
+        }
 
         // Default when there is no non-interactive authentication available
         // Type 5: return a null credential so that the login webflow will prepare login pages


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-8792

## Purpose

Force CAS to throw exceptions and display error pages without actually going through the expected web flow.

Supports both `lang.RuntimeException` and `javax.security.auth.login.LoginException`

- [x] It's OK to merge into feature branch now. However, must make this feature only enabled for non-production environments before release.

## Changes

Force CAS to throw exceptions and display error pages without actually going through the expected web flow.

<img width="1266" height="873" alt="org apereo cas services UnauthorizedServiceException" src="https://github.com/user-attachments/assets/322c6d13-1414-4153-b1c8-04a9052a39f5" />

<img width="1266" height="873" alt="io cos cas osf authentication exception InstitutionSsoSelectiveLoginDeniedExceptio" src="https://github.com/user-attachments/assets/36a22b42-f8e2-4af6-8197-537ac53eecd5" />


## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A
