### PR TITLE
[ENG-8754] Force throw a few HTTP errors for testing purpose

### DIFF
--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -332,6 +332,7 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
         LOGGER.debug("No valid username or verification key found in request parameters.");
 
         // Check 4: check "forceException=" query parameter
+        // TODO: disable this for production environment
         final String forcedException = request.getParameter(FORCE_EXCEPTION_PARAMETER_NAME);
         if (StringUtils.isNotBlank(forcedException)) {
             setSsoErrorContext(

--- a/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
+++ b/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
@@ -139,6 +139,7 @@ public class CasWebAppConfiguration implements WebMvcConfigurer {
                     final HttpServletRequest request,
                     final HttpServletResponse response
             ) throws IOException {
+                // TODO: disable this for production environment
                 var errorCodeString = request.getParameter("code");
                 if (StringUtils.isNotBlank(errorCodeString)) {
                     try {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-8754

## Purpose

Add a new controller to force throw a few HTTP errors for testing purpose

## Changes

Added a new controller to `CasWebAppConfiguration` for  force throw a few HTTP errors for testing purpose. These errors has dedicated templates that is very hard to trigger in normal user flow.

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

Similar to https://github.com/CenterForOpenScience/osf-cas/pull/87, it's OK to merge into feature branch now. However, must make this feature only enabled for non-production environments before release.
