### PR TITLE
[ENG-8927] Add dev mode for forcing errors/excpetions

### DIFF
--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -15,6 +15,13 @@ cas.server.prefix=${cas.server.name}
 # Tomcat Server
 #
 cas.server.tomcat.server-name=OSF CAS
+#
+# Dev Mode Options
+#
+cas.server.dev-mode.allow-force-authn-exception=${ALLOW_FORCE_AUTHN_EXCEPTION:false}
+cas.server.dev-mode.allow-force-http-error=${ALLOW_FORCE_HTTP_ERROR:false}
+#
+######################################################
 ########################################################################################################################
 
 ########################################################################################################################

--- a/etc/cas/config/local/cas-local.properties
+++ b/etc/cas/config/local/cas-local.properties
@@ -21,6 +21,11 @@ cas.server.tomcat.server-name=OSF CAS
 # cas.server.tomcat.http.enabled=true
 # cas.server.tomcat.http.attributes=
 # e.g. cas.server.tomcat.http.attributes.{attribute-name}={attributeValue}
+#
+# Dev Mode Options
+#
+cas.server.dev-mode.allow-force-authn-exception=true
+cas.server.dev-mode.allow-force-http-error=true
 ########################################################################################################################
 
 ########################################################################################################################

--- a/src/main/java/io/cos/cas/osf/configuration/model/DevModeProperties.java
+++ b/src/main/java/io/cos/cas/osf/configuration/model/DevModeProperties.java
@@ -1,0 +1,34 @@
+package io.cos.cas.osf.configuration.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link DevModeProperties}.
+ *
+ * @author Longze Chen
+ * @since 25.1.0
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class DevModeProperties implements Serializable {
+
+    /**
+     * Serialization metadata.
+     */
+    private static final long serialVersionUID = -1725182183570276203L;
+
+    /**
+     * Allow CAS to force throw authentication exceptions and to render respective error pages for testing purpose.
+     */
+    private boolean allowForceAuthnException = Boolean.FALSE;
+
+    /**
+     * Allow CAS to force http errors which have built-in rendering template for rendering and testing.
+     */
+    private boolean allowForceHttpError = Boolean.FALSE;
+}

--- a/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
+++ b/src/main/java/io/cos/cas/osf/web/config/OsfCasSupportActionsConfiguration.java
@@ -101,6 +101,7 @@ public class OsfCasSupportActionsConfiguration extends CasSupportActionsConfigur
                 adaptiveAuthenticationPolicy.getObject(),
                 centralAuthenticationService.getObject(),
                 jpaOsfDao.getObject(),
+                casProperties.getServer().getDevMode(),
                 casProperties.getAuthn().getOsfUrl(),
                 casProperties.getAuthn().getOsfApi(),
                 authnDelegationClients

--- a/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
+++ b/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
@@ -164,13 +164,15 @@ public class CasWebAppConfiguration implements WebMvcConfigurer {
         val mapping = new SimpleUrlHandlerMapping();
 
         val root = rootController();
-        val forceHttpError = forceHttpErrorController();
         mapping.setOrder(1);
         mapping.setAlwaysUseFullPath(true);
         mapping.setRootHandler(root);
         val urls = new HashMap<String, Object>();
         urls.put("/", root);
-        urls.put("/forceHttpError", forceHttpError);
+        if (casProperties.getServer().getDevMode().isAllowForceHttpError()) {
+            val forceHttpError = forceHttpErrorController();
+            urls.put("/forceHttpError", forceHttpError);
+        }
 
         mapping.setUrlMap(urls);
         return mapping;

--- a/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
+++ b/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.configuration.model.core;
 
+import io.cos.cas.osf.configuration.model.DevModeProperties;
+
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatProperties;
 import org.apereo.cas.configuration.support.RequiredProperty;
@@ -16,8 +18,13 @@ import java.io.Serializable;
 /**
  * This is {@link CasServerProperties}.
  *
+ * <p>OSF CAS Customization: add configuration settings to set dev mode options.</p>
+ *
  * @author Misagh Moayyed
  * @since 5.0.0
+ *
+ * @author Longze Chen
+ * @since 25.1.0
  */
 @RequiresModule(name = "cas-server-core", automated = true)
 @Getter
@@ -53,6 +60,12 @@ public class CasServerProperties implements Serializable {
      */
     @NestedConfigurationProperty
     private CasEmbeddedApacheTomcatProperties tomcat = new CasEmbeddedApacheTomcatProperties();
+
+    /**
+     * OSF CAS Customization: configuration settings that set dev mode options.
+     */
+    @NestedConfigurationProperty
+    private DevModeProperties devMode = new DevModeProperties();
 
     @JsonIgnore
     public String getLoginUrl() {

--- a/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
+++ b/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
@@ -1,0 +1,67 @@
+package org.apereo.cas.configuration.model.core;
+
+import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatProperties;
+import org.apereo.cas.configuration.support.RequiredProperty;
+import org.apereo.cas.configuration.support.RequiresModule;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link CasServerProperties}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+@RequiresModule(name = "cas-server-core", automated = true)
+@Getter
+@Setter
+@Accessors(chain = true)
+public class CasServerProperties implements Serializable {
+
+    private static final long serialVersionUID = 7876382696803430817L;
+
+    /**
+     * Full name of the CAS server. This is the public-facing address
+     * of the CAS deployment and not the individual node address,
+     * in the event that CAS is clustered.
+     */
+    @RequiredProperty
+    private String name = "https://cas.example.org:8443";
+
+    /**
+     * A concatenation of the server name plus the CAS context path.
+     * Deployments at root likely need to blank out this value.
+     */
+    @RequiredProperty
+    private String prefix = name.concat("/cas");
+
+    /**
+     * The CAS Server scope.
+     */
+    @RequiredProperty
+    private String scope = "example.org";
+
+    /**
+     * Configuration settings that control the embedded Apache Tomcat container.
+     */
+    @NestedConfigurationProperty
+    private CasEmbeddedApacheTomcatProperties tomcat = new CasEmbeddedApacheTomcatProperties();
+
+    @JsonIgnore
+    public String getLoginUrl() {
+        return getPrefix().concat(CasProtocolConstants.ENDPOINT_LOGIN);
+    }
+
+    @JsonIgnore
+    public String getLogoutUrl() {
+        return getPrefix().concat(CasProtocolConstants.ENDPOINT_LOGOUT);
+    }
+
+}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-8927

## Purpose

* Add configuration settings to set dev mode options
* Only allow forcing errors/exceptions in dev mode

## Changes

See **Purpose**

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

* Set `ALLOW_FORCE_AUTHN_EXCEPTION` and `ALLOW_FORCE_HTTP_ERROR` to true for staging and test servers
* Set `ALLOW_FORCE_AUTHN_EXCEPTION` and `ALLOW_FORCE_HTTP_ERROR` to false for the production server
