### PR TITLE
[ENG-8789] [ENG-8790] [ENG-8791] Exception Page rework

### DIFF
--- a/src/main/resources/static/css/cas.css
+++ b/src/main/resources/static/css/cas.css
@@ -880,6 +880,10 @@ body {
     flex: 1;
 }
 
+.login-error-card .card-message h1 {
+    text-align: center;
+}
+
 #serviceui {
     background-color: transparent;
 }
@@ -1027,6 +1031,7 @@ body {
 .login-instn-card .card-message,
 .login-error-card .card-message {
     padding: 0;
+    margin-top: 0.5rem
 }
 
 .login-error-card #errorInfo,

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casAccountDisabledView.html
+++ b/src/main/resources/templates/casAccountDisabledView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.accountdisabled.heading}"></h1>
                     <p th:utext="#{screen.accountdisabled.message}"></p>

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casAccountNotConfirmedIdPView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedIdPView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.accountnotconfirmedidp.heading}"></h1>
                     <p th:utext="#{screen.accountnotconfirmedidp.message}"></p>

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casAccountNotConfirmedOsfView.html
+++ b/src/main/resources/templates/casAccountNotConfirmedOsfView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.accountnotconfirmedosf.heading}"></h1>
                     <p th:utext="#{screen.accountnotconfirmedosf.message}"></p>

--- a/src/main/resources/templates/casGenericSuccessView.html
+++ b/src/main/resources/templates/casGenericSuccessView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title">
                     <span th:utext="#{screen.generic.loginsuccess.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoAccountInactiveView.html
+++ b/src/main/resources/templates/casInstitutionSsoAccountInactiveView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoAccountInactiveView.html
+++ b/src/main/resources/templates/casInstitutionSsoAccountInactiveView.html
@@ -14,9 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
                 <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>

--- a/src/main/resources/templates/casInstitutionSsoAttributeMissingView.html
+++ b/src/main/resources/templates/casInstitutionSsoAttributeMissingView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:utext="#{screen.institutionssoattributemissing.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoAttributeMissingView.html
+++ b/src/main/resources/templates/casInstitutionSsoAttributeMissingView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoAttributeParsingFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoAttributeParsingFailedView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoAttributeParsingFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoAttributeParsingFailedView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:utext="#{screen.institutionssoattributeparsingfailed.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoDuplicateIdentityView.html
+++ b/src/main/resources/templates/casInstitutionSsoDuplicateIdentityView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:utext="#{screen.institutionssoduplicateidentity.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoDuplicateIdentityView.html
+++ b/src/main/resources/templates/casInstitutionSsoDuplicateIdentityView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoFailedView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoFailedView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:utext="#{screen.institutionssofailed.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoMultipleEmailsNotSupportedView.html
+++ b/src/main/resources/templates/casInstitutionSsoMultipleEmailsNotSupportedView.html
@@ -14,10 +14,6 @@
 
     <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
         <section class="login-error-card">
-            <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                <span th:utext="#{screen.authnerror.tips}"></span>
-            </section>
-            <hr class="my-4" />
             <section class="card-message">
                 <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                 <p th:utext="#{screen.institutionssomultipleemailsnotsupported.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoMultipleEmailsNotSupportedView.html
+++ b/src/main/resources/templates/casInstitutionSsoMultipleEmailsNotSupportedView.html
@@ -14,11 +14,6 @@
 
     <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
         <section class="login-error-card">
-            <section>
-                <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                    <a href="fragments/osfbannerui.html"></a>
-                </div>
-            </section>
             <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                 <span th:utext="#{screen.authnerror.tips}"></span>
             </section>

--- a/src/main/resources/templates/casInstitutionSsoOsfApiFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoOsfApiFailedView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:utext="#{screen.institutionssoosfapifailed.message}"></p>

--- a/src/main/resources/templates/casInstitutionSsoOsfApiFailedView.html
+++ b/src/main/resources/templates/casInstitutionSsoOsfApiFailedView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
+++ b/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
+++ b/src/main/resources/templates/casInstitutionSsoSelectiveLoginDeniedView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.institutionssofailed.heading}"></h1>
                     <p th:if="${#strings.isEmpty(osfCasSsoErrorContext.institutionSupportEmail)}" th:utext="#{screen.institutionssoselectivelogindenied.standard.message}"></p>

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInvalidUserStatusView.html
+++ b/src/main/resources/templates/casInvalidUserStatusView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.invaliduserstatus.heading}"></h1>
                     <p th:utext="#{screen.invaliduserstatus.message}"></p>

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casInvalidVerificationKeyView.html
+++ b/src/main/resources/templates/casInvalidVerificationKeyView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.invalidverificationkey.heading}"></h1>
                     <p th:utext="#{screen.invalidverificationkey.message}"></p>

--- a/src/main/resources/templates/casLogoutView.html
+++ b/src/main/resources/templates/casLogoutView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title">
                     <span th:utext="#{screen.generic.logoutsuccess.tips}"></span>
                 </section>

--- a/src/main/resources/templates/casPac4jStopWebflow.html
+++ b/src/main/resources/templates/casPac4jStopWebflow.html
@@ -14,10 +14,6 @@
 
     <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
         <section class="login-error-card">
-            <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                <span th:utext="#{screen.authnerror.tips}"></span>
-            </section>
-            <hr class="my-4" />
             <section class="card-message">
                 <h1 th:utext="#{screen.pac4j.error.heading}"></h1>
                 <p th:utext="#{screen.pac4j.error.message}"></p>

--- a/src/main/resources/templates/casPac4jStopWebflow.html
+++ b/src/main/resources/templates/casPac4jStopWebflow.html
@@ -14,11 +14,6 @@
 
     <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
         <section class="login-error-card">
-            <section>
-                <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                    <a href="fragments/osfbannerui.html"></a>
-                </div>
-            </section>
             <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                 <span th:utext="#{screen.authnerror.tips}"></span>
             </section>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.service.error.heading}"></h1>
                     <p th:if="${rootCauseException != null and rootCauseException.code != null}" th:utext="#{${rootCauseException.code}}"></p>

--- a/src/main/resources/templates/casServiceErrorView.html
+++ b/src/main/resources/templates/casServiceErrorView.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -14,11 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -14,10 +14,6 @@
 
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-                <hr class="my-4" />
                 <section class="card-message">
                     <h1 th:utext="#{screen.unavailable.heading}"></h1>
                     <div th:utext="#{screen.unavailable.message}"></div>

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-
-                <hr class="my-4" />
-
                 <section class="card-message">
                     <h1 th:utext="#{screen.error.page.accessdenied}"></h1>
                     <p th:utext="#{screen.error.page.permissiondenied}"></p>

--- a/src/main/resources/templates/error/401.html
+++ b/src/main/resources/templates/error/401.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
-
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-
-                <hr class="my-4" />
-
                 <section class="card-message">
                     <h1 th:utext="#{screen.error.page.authdenied}"></h1>
                     <p th:utext="#{screen.error.page.permissiondenied}"></p>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
-
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-
-                <hr class="my-4" />
-
                 <section class="card-message">
                     <h1 th:utext="#{screen.error.page.notfound}"></h1>
                     <p th:utext="#{screen.error.page.doesnotexist}"></p>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
-
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -14,10 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-
                 <hr class="my-4" />
 
                 <section class="card-message">

--- a/src/main/resources/templates/error/405.html
+++ b/src/main/resources/templates/error/405.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
-
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
-                    <span th:utext="#{screen.authnerror.tips}"></span>
-                </section>
-
-                <hr class="my-4" />
-
                 <section class="card-message">
                     <h1 th:utext="#{screen.blocked.header}"></h1>
                     <p th:utext="#{screen.blocked.message}"></p>

--- a/src/main/resources/templates/error/423.html
+++ b/src/main/resources/templates/error/423.html
@@ -14,12 +14,6 @@
         <div class="d-flex justify-content-center flex-md-row flex-column mdc-card mdc-card-content w-lg-30">
             <section class="login-error-card">
 
-                <section>
-                    <div th:replace="fragments/osfbannerui :: osfBannerUI">
-                        <a href="fragments/osfbannerui.html"></a>
-                    </div>
-                </section>
-
                 <section class="text-without-mdi text-center text-bold text-large margin-large-vertical title-danger">
                     <span th:utext="#{screen.authnerror.tips}"></span>
                 </section>


### PR DESCRIPTION
## Ticket

* https://openscience.atlassian.net/browse/ENG-8789
* https://openscience.atlassian.net/browse/ENG-8790
* Follow-up for closed ticket https://openscience.atlassian.net/browse/ENG-8791

## Purpose

Rework exception pages, a few examples

OSF Login exception

<img width="1517" height="1181" alt="osf-login-failed" src="https://github.com/user-attachments/assets/4a0749db-fc5b-4fce-a1f7-cfe8b4e891ec" />

Institution SSO exception

<img width="1517" height="1181" alt="institution-sso-failed" src="https://github.com/user-attachments/assets/d936a205-441b-4f77-816c-6293842b3c70" />

Http Error

<img width="1517" height="1181" alt="http-error-404" src="https://github.com/user-attachments/assets/0fd43372-7fdb-4822-a2bc-fb55cc775548" />

## Changes

* Remove banner UI
* Remove error tip
* Adjust style
* We get free background and button style from https://github.com/CenterForOpenScience/osf-cas/pull/97 👍 @futa-ikeda 

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A
