### PR TITLE
[ENG-10293] Hide institution with in-progress SSO setup from the institution login dropdown list

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -52,6 +52,22 @@ public final class OsfInstitutionUtils {
         }
         final Map<String, String> institutionLoginUrlMap = new HashMap<>();
         for (final OsfInstitution institution: institutionList) {
+            final SsoAvailability ssoAvailability = institution.getSsoAvailability();
+            if (ssoAvailability == null) {
+                LOGGER.error(
+                        "Skipped due to invalid SSO Availability: [institutionId={}]",
+                        institution.getInstitutionId()
+                );
+                continue;
+            }
+            if (!ssoAvailability.isPublic()) {
+                LOGGER.debug(
+                        "Skipped because SSO Availability is not public: [institutionId={}, ssoAvailability={}]",
+                        institution.getInstitutionId(),
+                        ssoAvailability.getId()
+                );
+                continue;
+            }
             final DelegationProtocol delegationProtocol = institution.getDelegationProtocol();
             if (DelegationProtocol.SAML_SHIB.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(

--- a/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/OsfInstitutionUtils.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This is {@link OsfInstitutionUtils}.
+ * This is {@link OsfInstitutionUtils}, which provides helper methods supporting the institution SSO login flow.
  *
  * @author Longze Chen
  * @since 21.0.0
@@ -54,6 +54,8 @@ public final class OsfInstitutionUtils {
         for (final OsfInstitution institution: institutionList) {
             final SsoAvailability ssoAvailability = institution.getSsoAvailability();
             if (ssoAvailability == null) {
+                // Catch a rare exception case where OSF DB has changed the choices of the field
+                // `sso_availability` in table `osf_institution` without syncing with CAS.
                 LOGGER.error(
                         "Skipped due to invalid SSO Availability: [institutionId={}]",
                         institution.getInstitutionId()
@@ -61,6 +63,7 @@ public final class OsfInstitutionUtils {
                 continue;
             }
             if (!ssoAvailability.isPublic()) {
+                // Hide institutions of which SSO Availability is not Public
                 LOGGER.debug(
                         "Skipped because SSO Availability is not public: [institutionId={}, ssoAvailability={}]",
                         institution.getInstitutionId(),

--- a/src/main/java/io/cos/cas/osf/authentication/support/SsoAvailability.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/SsoAvailability.java
@@ -1,7 +1,8 @@
 package io.cos.cas.osf.authentication.support;
 
 /**
- * This is {@link SsoAvailability}.
+ * This is {@link SsoAvailability}, which is used in {@link io.cos.cas.osf.model.OsfInstitution}
+ * to map to the types/choices of its counterpart in the OSF model.
  *
  * @author Longze Chen
  * @since 26.1.0
@@ -40,6 +41,9 @@ public enum SsoAvailability {
         throw new IllegalArgumentException("No matching type for id " + id);
     }
 
+    /**
+     * @return whether the enum type is {@link SsoAvailability#PUBLIC}.
+     */
     public boolean isPublic () {
         return SsoAvailability.PUBLIC.equals(this);
     }

--- a/src/main/java/io/cos/cas/osf/authentication/support/SsoAvailability.java
+++ b/src/main/java/io/cos/cas/osf/authentication/support/SsoAvailability.java
@@ -40,6 +40,10 @@ public enum SsoAvailability {
         throw new IllegalArgumentException("No matching type for id " + id);
     }
 
+    public boolean isPublic () {
+        return SsoAvailability.PUBLIC.equals(this);
+    }
+
     public final String getId() {
         return id;
     }


### PR DESCRIPTION
## Ticket

[ENG-10293](https://openscience.atlassian.net/browse/ENG-10293)

## Purpose

Hide institution with in-progress SSO setup from the institution login dropdown list

## Changes

* Only allow institutions with public SSO Availability to be inserted into the institution login URL map.
* Handle invalid choice exception

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

N/A


[ENG-10293]: https://openscience.atlassian.net/browse/ENG-10293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ