### PR TITLE
[ENG-11116] Update cas.properties for JPA / DB access

### DIFF
--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -142,8 +142,10 @@ cas.authn.osf-postgres.order=0
 cas.authn.osf-postgres.jpa.user=${OSF_DB_USER:postgres}
 cas.authn.osf-postgres.jpa.password=${OSF_DB_PASSWORD:}
 cas.authn.osf-postgres.jpa.driver-class=${OSF_DB_DRIVER_CLASS:org.postgresql.Driver}
-cas.authn.osf-postgres.jpa.url=${OSF_DB_URL:jdbc:postgresql://192.168.168.167:5432/osf?targetServerType=master&readOnly=true}
+cas.authn.osf-postgres.jpa.url=${OSF_DB_URL:jdbc:postgresql://192.168.168.167:5432/osf?targetServerType=preferSecondary&readOnly=true&readOnlyMode=always}
 cas.authn.osf-postgres.jpa.dialect=${OSF_DB_HIBERNATE_DIALECT:io.cos.cas.osf.hibernate.dialect.OsfPostgresDialect}
+cas.authn.osf-postgres.jpa.autocommit=false
+cas.authn.osf-postgres.jpa.ddl-auto=validate
 ########################################################################################################################
 
 ########################################################################################################################
@@ -161,7 +163,7 @@ cas.jdbc.case-insensitive=false
 cas.ticket.registry.jpa.user=${CAS_DB_USER:postgres}
 cas.ticket.registry.jpa.password=${CAS_DB_PASSWORD:}
 cas.ticket.registry.jpa.driver-class=${CAS_DB_DRIVER_CLASS:org.postgresql.Driver}
-cas.ticket.registry.jpa.url=${CAS_DB_URL:jdbc:postgresql://127.0.0.1:5432/osf-cas?targetServerType=master}
+cas.ticket.registry.jpa.url=${CAS_DB_URL:jdbc:postgresql://127.0.0.1:5432/osf-cas?targetServerType=primary}
 cas.ticket.registry.jpa.dialect=${CAS_DB_HIBERNATE_DIALECT:org.hibernate.dialect.PostgreSQL95Dialect}
 cas.ticket.registry.jpa.ddl-auto=update
 cas.ticket.registry.jpa.default-catalog=

--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -144,8 +144,8 @@ cas.authn.osf-postgres.jpa.password=${OSF_DB_PASSWORD:}
 cas.authn.osf-postgres.jpa.driver-class=${OSF_DB_DRIVER_CLASS:org.postgresql.Driver}
 cas.authn.osf-postgres.jpa.url=${OSF_DB_URL:jdbc:postgresql://192.168.168.167:5432/osf?targetServerType=preferSecondary&readOnly=true&readOnlyMode=always}
 cas.authn.osf-postgres.jpa.dialect=${OSF_DB_HIBERNATE_DIALECT:io.cos.cas.osf.hibernate.dialect.OsfPostgresDialect}
-cas.authn.osf-postgres.jpa.autocommit=false
-cas.authn.osf-postgres.jpa.ddl-auto=validate
+cas.authn.osf-postgres.jpa.autocommit=${OSF_DB_AUTOCOMMIT:false}
+cas.authn.osf-postgres.jpa.ddl-auto=${OSF_DB_DDLAUTO:validate}
 ########################################################################################################################
 
 ########################################################################################################################

--- a/etc/cas/config/local/cas-local.properties
+++ b/etc/cas/config/local/cas-local.properties
@@ -148,8 +148,10 @@ cas.authn.osf-postgres.order=0
 cas.authn.osf-postgres.jpa.user=postgres
 cas.authn.osf-postgres.jpa.password=
 cas.authn.osf-postgres.jpa.driver-class=org.postgresql.Driver
-cas.authn.osf-postgres.jpa.url=jdbc:postgresql://192.168.168.167:5432/osf?targetServerType=master&readOnly=true
+cas.authn.osf-postgres.jpa.url=jdbc:postgresql://192.168.168.167:5432/osf?targetServerType=preferSecondary&readOnly=true&readOnlyMode=always
 cas.authn.osf-postgres.jpa.dialect=io.cos.cas.osf.hibernate.dialect.OsfPostgresDialect
+cas.authn.osf-postgres.jpa.autocommit=false
+cas.authn.osf-postgres.jpa.ddl-auto=validate
 ########################################################################################################################
 
 ########################################################################################################################
@@ -166,10 +168,10 @@ cas.jdbc.case-insensitive=false
 #
 # General JPA Settings
 #
-cas.ticket.registry.jpa.user=longzechen
+cas.ticket.registry.jpa.user=postgres
 cas.ticket.registry.jpa.password=
 cas.ticket.registry.jpa.driver-class=org.postgresql.Driver
-cas.ticket.registry.jpa.url=jdbc:postgresql://192.168.168.167:54321/newcas?targetServerType=master
+cas.ticket.registry.jpa.url=jdbc:postgresql://192.168.168.167:2345/cas?targetServerType=primary
 cas.ticket.registry.jpa.dialect=org.hibernate.dialect.PostgreSQL95Dialect
 cas.ticket.registry.jpa.ddl-auto=update
 cas.ticket.registry.jpa.default-catalog=


### PR DESCRIPTION
## Ticket

[ENG-11116](https://openscience.atlassian.net/browse/ENG-11116)

## Purpose

Update cas.properties for JPA / DB access

## Changes

* Improve read-only connection for OSF DB
* Update JPA to only validate for OSF DB

## Dev Notes

N/A

## QA Notes

N/A

## Dev-Ops Notes

Changes in this PR does not affect servers. The actual change must be made in public and/or private charts.

[ENG-11116]: https://openscience.atlassian.net/browse/ENG-11116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ