### PR TITLE
[ENG-11829] POC: Rewrite ORCiD SSO to use OSF credentials and flow and release access token to OSF

### DIFF
--- a/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
+++ b/src/main/java/io/cos/cas/osf/authentication/credential/OsfPostgresCredential.java
@@ -44,6 +44,8 @@ public class OsfPostgresCredential extends RememberMeUsernamePasswordCredential 
 
     private static DelegationProtocol DEFAULT_DELEGATION_PROTOCOL = DelegationProtocol.NONE;
 
+    public static String AUTHENTICATION_ATTRIBUTE_ORCID_ACCESS_TOKEN = "orcidAccessToken";
+
     /**
      * The one-time and ephemeral OSF verification key.
      */
@@ -83,6 +85,10 @@ public class OsfPostgresCredential extends RememberMeUsernamePasswordCredential 
      * The authentication attributes that are parsed from raw authentication response.
      */
     private Map<String, String> delegationAttributes = new LinkedHashMap<>();
+
+    private String orcidId;
+
+    private String orcidAccessToken;
 
     @Override
     public String getId() {

--- a/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
+++ b/src/main/java/io/cos/cas/osf/authentication/handler/support/OsfPostgresAuthenticationHandler.java
@@ -80,7 +80,7 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
     ) throws GeneralSecurityException {
         OsfPostgresCredential osfPostgresCredential = (OsfPostgresCredential) credential;
         transformUsername(osfPostgresCredential);
-        if (osfPostgresCredential.isRemotePrincipal()) {
+        if (osfPostgresCredential.isRemotePrincipal() || osfPostgresCredential.getOrcidId() != null) {
             osfPostgresCredential.setPassword(null);
             osfPostgresCredential.setVerificationKey(null);
         } else {
@@ -114,6 +114,8 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
         final boolean isTermsOfServiceChecked = credential.isTermsOfServiceChecked();
         final boolean isRemotePrincipal = credential.isRemotePrincipal();
         final DelegationProtocol delegationProtocol = credential.getDelegationProtocol();
+        final String orcidId = credential.getOrcidId();
+        final String orcidAccessToken = credential.getOrcidAccessToken();
 
         LOGGER.debug(
                 "Credential metadata: username=[{}], password=[{}], verificationKey=[{}], oneTimePassword=[{}], " +
@@ -127,6 +129,22 @@ public class OsfPostgresAuthenticationHandler extends AbstractPreAndPostProcessi
                 institutionId,
                 delegationProtocol
         );
+
+        if (StringUtils.isNoneBlank(orcidId)) {
+            final String principalId = "OrcidProfile#" + orcidId;
+            final Map<String, List<Object>> attributes = new LinkedHashMap<>();
+            attributes.put("orcidAccessToken", Collections.singletonList(orcidAccessToken));
+            LOGGER.debug(">>>> Authenticating credential for ORCiD SSO");
+            LOGGER.debug(">>>> ---- username from credential = {}", username);
+            credential.setUsername(principalId);
+            LOGGER.debug(">>>> ---- username from credential updated = {}", credential.getUsername());
+            LOGGER.debug(">>>> ---- orcidId = {}", orcidId);
+            LOGGER.debug(">>>> ---- orcidAccessToken = {}", orcidAccessToken);
+            LOGGER.debug(">>>> ---- principalId = {}", principalId);
+            final Principal principal = this.principalFactory.createPrincipal(principalId, attributes);
+            final List<MessageDescriptor> warnings = new ArrayList<>();
+            return createHandlerResult(credential, principal, warnings);
+        }
 
         final OsfUser osfUser = jpaOsfDao.findOneUserByEmail(username);
         if (osfUser == null) {

--- a/src/main/java/io/cos/cas/osf/authentication/metadata/OsfPostgresAuthenticationMetaDataPopulator.java
+++ b/src/main/java/io/cos/cas/osf/authentication/metadata/OsfPostgresAuthenticationMetaDataPopulator.java
@@ -27,13 +27,14 @@ public class OsfPostgresAuthenticationMetaDataPopulator implements Authenticatio
         transaction.getPrimaryCredential().ifPresent(r -> {
             final OsfPostgresCredential credential = (OsfPostgresCredential) r;
             LOGGER.debug(
-                    "Credential is of type [{}], thus adding attributes [{}, {}, {}, {}, {}]",
+                    "Credential is of type [{}], thus adding attributes [{}, {}, {}, {}, {} {}]",
                     OsfPostgresCredential.class.getSimpleName(),
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME,
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMOTE_PRINCIPAL,
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_DELEGATION_PROTOCOL,
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_INSTITUTION_ID,
-                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_TOS_CONSENT
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_TOS_CONSENT,
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_ORCID_ACCESS_TOKEN
             );
             builder.addAttribute(
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME,
@@ -54,6 +55,10 @@ public class OsfPostgresAuthenticationMetaDataPopulator implements Authenticatio
             builder.addAttribute(
                     OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_INSTITUTION_ID,
                     credential.getInstitutionId()
+            );
+            builder.addAttribute(
+                    OsfPostgresCredential.AUTHENTICATION_ATTRIBUTE_ORCID_ACCESS_TOKEN,
+                    credential.getOrcidAccessToken()
             );
         });
     }

--- a/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
+++ b/src/main/java/io/cos/cas/osf/web/flow/login/OsfPrincipalFromNonInteractiveCredentialsAction.java
@@ -70,6 +70,8 @@ import org.apereo.cas.web.support.WebUtils;
 import org.json.JSONObject;
 import org.json.XML;
 
+import org.pac4j.oauth.profile.orcid.OrcidProfile;
+
 import org.springframework.util.ResourceUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
@@ -255,7 +257,18 @@ public class OsfPrincipalFromNonInteractiveCredentialsAction extends AbstractNon
                             clientName,
                             credential.getId()
                     );
-                    return credential;
+                    LOGGER.debug(">>>> credential = {}", ((ClientCredential) credential).getCredentials().toString());
+                    LOGGER.debug(">>>> profile = {}", ((ClientCredential) credential).getUserProfile().toString());
+                    final OrcidProfile orcidUserProfile = (OrcidProfile) ((ClientCredential) credential).getUserProfile();
+                    final String orcidId = orcidUserProfile.getId();
+                    final String accessToken = (String) orcidUserProfile.getAttribute("access_token");
+                    LOGGER.debug(">>>> orcidId = {}", orcidId);
+                    LOGGER.debug(">>>> orcidAccessToken = {}", accessToken);
+                    OsfPostgresCredential osfPostgresCredential = new OsfPostgresCredential();
+                    osfPostgresCredential.setOrcidAccessToken(accessToken);
+                    osfPostgresCredential.setOrcidId(orcidId);
+                    osfPostgresCredential.setUsername("OrcidProfile#" + orcidId);
+                    return osfPostgresCredential;
                 }
                 // Type 2: institution SSO via pac4j authentication delegation using the CAS protocol
                 if (authnDelegationClients.get(INSTITUTION_CLIENTS_PARAMETER_NAME).contains(clientName)) {

--- a/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
+++ b/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
@@ -2,6 +2,9 @@ package org.pac4j.oauth.profile.creator;
 
 import com.github.scribejava.core.model.*;
 import com.github.scribejava.core.oauth.OAuth20Service;
+
+import org.apache.commons.lang3.StringUtils;
+
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -12,11 +15,17 @@ import org.pac4j.oauth.profile.OAuth20Profile;
 /**
  * OAuth 2.0 profile creator.
  *
+ * OSF CAS Customization: modified {@code addAccessTokenToProfile} to include refresh token in profile attributes.
+ *
  * @author Jerome Leleu
+ * @author Longze Chen
  * @since 2.0.0
+ * @version 4.1.0
  */
 public class OAuth20ProfileCreator<U extends OAuth20Profile>
         extends OAuthProfileCreator<OAuth20Credentials, U, OAuth20Configuration, OAuth2AccessToken, OAuth20Service> {
+
+    private static final String REFRESH_TOKEN = "refresh_token";
 
     public OAuth20ProfileCreator(final OAuth20Configuration configuration, final IndirectClient client) {
         super(configuration, client);
@@ -33,6 +42,11 @@ public class OAuth20ProfileCreator<U extends OAuth20Profile>
             final String token = accessToken.getAccessToken();
             logger.debug("add access_token: {} to profile", token);
             profile.setAccessToken(token);
+            final String refreshToken = accessToken.getRefreshToken();
+            if (StringUtils.isNoneBlank(refreshToken)) {
+                logger.debug("add refresh_token: {} to profile", token);
+                profile.addAttribute(REFRESH_TOKEN, refreshToken);
+            }
         }
     }
 

--- a/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
+++ b/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
@@ -1,0 +1,50 @@
+package org.pac4j.oauth.profile.creator;
+
+import com.github.scribejava.core.model.*;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.oauth.config.OAuthConfiguration;
+import org.pac4j.oauth.credentials.OAuth20Credentials;
+import org.pac4j.oauth.profile.OAuth20Profile;
+
+/**
+ * OAuth 2.0 profile creator.
+ *
+ * @author Jerome Leleu
+ * @since 2.0.0
+ */
+public class OAuth20ProfileCreator<U extends OAuth20Profile>
+        extends OAuthProfileCreator<OAuth20Credentials, U, OAuth20Configuration, OAuth2AccessToken, OAuth20Service> {
+
+    public OAuth20ProfileCreator(final OAuth20Configuration configuration, final IndirectClient client) {
+        super(configuration, client);
+    }
+
+    @Override
+    protected OAuth2AccessToken getAccessToken(final OAuth20Credentials credentials) {
+        return credentials.getAccessToken();
+    }
+
+    @Override
+    protected void addAccessTokenToProfile(final U profile, final OAuth2AccessToken accessToken) {
+        if (profile != null) {
+            final String token = accessToken.getAccessToken();
+            logger.debug("add access_token: {} to profile", token);
+            profile.setAccessToken(token);
+        }
+    }
+
+    @Override
+    protected void signRequest(final OAuth20Service service, final OAuth2AccessToken accessToken,
+                               final OAuthRequest request) {
+        service.signRequest(accessToken, request);
+        if (this.configuration.isTokenAsHeader()) {
+            request.addHeader(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BEARER_HEADER_PREFIX + accessToken.getAccessToken());
+        }
+        if (Verb.POST.equals(request.getVerb())) {
+            request.addParameter(OAuthConfiguration.OAUTH_TOKEN, accessToken.getAccessToken());
+        }
+    }
+}

--- a/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfileDefinition.java
+++ b/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfileDefinition.java
@@ -11,6 +11,8 @@ import org.pac4j.scribe.model.OrcidToken;
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * This class is the Orcid profile definition.
  *
@@ -19,6 +21,7 @@ import com.github.scribejava.core.model.OAuth2AccessToken;
  * @since 1.6.0
  * @version 4.0.3
  */
+@Slf4j
 public class OrcidProfileDefinition extends OAuth20ProfileDefinition<OrcidProfile, OAuth20Configuration> {
 
     public static final String ORCID = "common:path";
@@ -41,6 +44,13 @@ public class OrcidProfileDefinition extends OAuth20ProfileDefinition<OrcidProfil
     @Override
     public String getProfileUrl(final OAuth2AccessToken accessToken, final OAuth20Configuration configuration) {
         if (accessToken instanceof OrcidToken) {
+            LOGGER.debug(">>>> access token object = {}", accessToken);
+            LOGGER.debug(">>>> ---- at = {}", accessToken.getAccessToken());
+            LOGGER.debug(">>>> ---- rt = {}", accessToken.getRefreshToken());
+            LOGGER.debug(">>>> ---- exp = {}", accessToken.getExpiresIn());
+            LOGGER.debug(">>>> ---- scope = {}", accessToken.getScope());
+            LOGGER.debug(">>>> ---- type = {}", accessToken.getTokenType());
+
             return String.format("https://pub.orcid.org/v2.0/%s/record", ((OrcidToken) accessToken).getOrcid());
         } else {
             throw new OAuthException("Token in getProfileUrl is not an OrcidToken");


### PR DESCRIPTION
## Ticket

[ENG-11829](https://openscience.atlassian.net/browse/ENG-11829)

## Purpose

POC: Rewrite ORCiD SSO to use OSF credentials and flow and release access token to OSF

* This is a temporary PoC implementation (with debugging logs) that let ORCiD SSO use OSF's credential/authentication flow.
* Need to move this to its own credential/authentication flow for the full implementation.

## Changes

TBD

## Dev Notes

TBD

## QA Notes

TBD

## Dev-Ops Notes

TBD


[ENG-11829]: https://openscience.atlassian.net/browse/ENG-11829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ